### PR TITLE
Project Automation - Create Set_Sprint_Field.yml

### DIFF
--- a/.github/workflows/Set_Sprint_Field.yml
+++ b/.github/workflows/Set_Sprint_Field.yml
@@ -1,0 +1,13 @@
+name: Project - Set Sprint
+
+on:
+  pull_request_target:
+    # We will ensure the sprint is the current sprint when an issue is (re)opened, synchronized, or edited
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  call-reusable-job:
+    permissions:
+        contents: read
+    uses: rapidsai/gpu-xb-ai/.github/workflows/reusable-project-set-sprint.yml@main
+    secrets: inherit


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/gpu-xb-ai/issues/89

Adds a small caller workflow to https://github.com/rapidsai/gpu-xb-ai/blob/main/.github/workflows/Set_Sprint_Field.yml; automatically setting PRs to the current sprint in our tracking project.

See:
https://github.com/rapidsai/legate-dataframe/blob/main/.github/workflows/Set_Sprint_Field.yml for the same workflow