### PR TITLE
Use sparse histograms

### DIFF
--- a/legateboost/models/tree.py
+++ b/legateboost/models/tree.py
@@ -92,6 +92,10 @@ class Tree(BaseModel):
         task.add_alignment(g_, h_)
         task.add_alignment(g_, X_)
 
+        # legate crashes if this is removed ????
+        fake_store = cn.zeros((1,), dtype=cn.float64)
+        task.add_input(get_store(fake_store))
+
         # outputs
         leaf_value = get_legate_runtime().create_store(
             types.float64, (max_nodes, num_outputs)

--- a/legateboost/models/tree.py
+++ b/legateboost/models/tree.py
@@ -70,7 +70,7 @@ class Tree(BaseModel):
         split_proposals = split_proposals.T
 
         unique = [cn.unique(row) for row in split_proposals]
-        row_pointers = cn.array([0] + [len(row) for row in unique], dtype=cn.int32)
+        row_pointers = cn.cumsum([0] + [len(row) for row in unique], dtype=cn.int32)
         unique = cn.concatenate(unique)
 
         return unique, row_pointers

--- a/legateboost/models/tree.py
+++ b/legateboost/models/tree.py
@@ -92,10 +92,6 @@ class Tree(BaseModel):
         task.add_alignment(g_, h_)
         task.add_alignment(g_, X_)
 
-        # legate crashes if this is removed ????
-        fake_store = cn.zeros((1,), dtype=cn.float64)
-        task.add_input(get_store(fake_store))
-
         # outputs
         leaf_value = get_legate_runtime().create_store(
             types.float64, (max_nodes, num_outputs)

--- a/legateboost/test/models/test_tree.py
+++ b/legateboost/test/models/test_tree.py
@@ -13,6 +13,19 @@ def test_determinism(max_depth):
     check_determinism(lb.models.Tree(max_depth=max_depth))
 
 
+def test_basic():
+    # tree loss can go to zero
+    X = cn.array([[0.0], [1.0]])
+    g = cn.array([[0.0], [-1.0]])
+    h = cn.array([[1.0], [1.0]])
+    model = (
+        lb.models.Tree(max_depth=1, alpha=0.0)
+        .set_random_state(np.random.RandomState(2))
+        .fit(X, g, h)
+    )
+    assert np.allclose(model.predict(X), np.array([[0.0], [1.0]]))
+
+
 @pytest.mark.parametrize("num_outputs", [1, 5])
 def test_improving_with_depth(num_outputs):
     rs = cn.random.RandomState(0)

--- a/src/mapper.cc
+++ b/src/mapper.cc
@@ -37,13 +37,18 @@ legate::Scalar LegateboostMapper::tunable_value(legate::TunableID /*tunable_id*/
 std::vector<legate::mapping::StoreMapping> LegateboostMapper::store_mappings(
   const legate::mapping::Task& task, const std::vector<legate::mapping::StoreTarget>& options)
 {
-  // Enforce c-ordering for all inputs
+  auto task_id = task.task_id();
+  // Enforce c-ordering for these tasks
+  std::set<LegateBoostOpCode> row_major_only = {BUILD_TREE};
   std::vector<legate::mapping::StoreMapping> mappings;
-  for (auto input : task.inputs()) {
-    mappings.push_back(
-      legate::mapping::StoreMapping::default_mapping(input.data(), options.front()));
-    mappings.back().policy().ordering.set_c_order();
-    mappings.back().policy().exact = true;
+  if (row_major_only.count(static_cast<LegateBoostOpCode>(task_id))) {
+    for (auto input : task.inputs()) {
+      mappings.push_back(
+        legate::mapping::StoreMapping::default_mapping(input.data(), options.front()));
+      mappings.back().policy().ordering.set_c_order();
+      mappings.back().policy().exact = true;
+    }
+    return mappings;
   }
   return mappings;
 }

--- a/src/mapper.cc
+++ b/src/mapper.cc
@@ -37,38 +37,15 @@ legate::Scalar LegateboostMapper::tunable_value(legate::TunableID /*tunable_id*/
 std::vector<legate::mapping::StoreMapping> LegateboostMapper::store_mappings(
   const legate::mapping::Task& task, const std::vector<legate::mapping::StoreTarget>& options)
 {
-  auto task_id = task.task_id();
-  switch (task_id) {
-    case GATHER:
-    case PREDICT: {
-      std::vector<legate::mapping::StoreMapping> mappings;
-      auto input_x = task.input(0);
-      mappings.push_back(
-        legate::mapping::StoreMapping::default_mapping(input_x.data(), options.front()));
-      mappings.back().policy().ordering.set_c_order();
-      mappings.back().policy().exact = true;
-      return std::move(mappings);
-    }
-    case BUILD_TREE: {
-      std::vector<legate::mapping::StoreMapping> mappings;
-      auto input_x = task.input(0);
-      mappings.push_back(
-        legate::mapping::StoreMapping::default_mapping(input_x.data(), options.front()));
-      mappings.back().policy().ordering.set_c_order();
-      mappings.back().policy().exact = true;
-      auto input_splits              = task.input(3);
-      mappings.push_back(
-        legate::mapping::StoreMapping::default_mapping(input_splits.data(), options.front()));
-      mappings.back().policy().ordering.set_c_order();
-      mappings.back().policy().exact = true;
-      return std::move(mappings);
-    }
-    default: {
-      return {};
-    }
+  // Enforce c-ordering for all inputs
+  std::vector<legate::mapping::StoreMapping> mappings;
+  for (auto input : task.inputs()) {
+    mappings.push_back(
+      legate::mapping::StoreMapping::default_mapping(input.data(), options.front()));
+    mappings.back().policy().ordering.set_c_order();
+    mappings.back().policy().exact = true;
   }
-  assert(false);
-  return {};
+  return mappings;
 }
 
 }  // namespace legateboost

--- a/src/models/tree/build_tree.cc
+++ b/src/models/tree/build_tree.cc
@@ -102,24 +102,24 @@ void WriteTreeOutput(legate::TaskContext context, const Tree& tree)
   WriteOutput(context.output(4).data(), tree.hessian);
 }
 
+template <typename T>
 struct TreeBuilder {
   TreeBuilder(int32_t num_rows,
               int32_t num_features,
               int32_t num_outputs,
               int32_t max_nodes,
-              int32_t samples_per_feature)
+              SparseSplitProposals<T> split_proposals)
     : num_rows(num_rows),
       num_features(num_features),
       num_outputs(num_outputs),
       max_nodes(max_nodes),
-      samples_per_feature(samples_per_feature),
-      histogram_buffer(legate::create_buffer<GPair, 4>(
-        {max_nodes, num_features, num_outputs, samples_per_feature})),
+      split_proposals(split_proposals),
+      histogram_buffer(
+        legate::create_buffer<GPair, 3>({max_nodes, split_proposals.histogram_size, num_outputs})),
       positions(num_rows, 0)
   {
-    auto ptr = histogram_buffer.ptr({0, 0, 0, 0});
-    std::fill(
-      ptr, ptr + max_nodes * num_features * num_outputs * samples_per_feature, GPair{0.0, 0.0});
+    auto ptr = histogram_buffer.ptr({0, 0, 0});
+    std::fill(ptr, ptr + max_nodes * split_proposals.histogram_size * num_outputs, GPair{0.0, 0.0});
   }
   ~TreeBuilder() { histogram_buffer.destroy(); }
   template <typename TYPE>
@@ -128,7 +128,6 @@ struct TreeBuilder {
                         Tree& tree,
                         legate::AccessorRO<TYPE, 3> X,
                         legate::Rect<3> X_shape,
-                        legate::AccessorRO<TYPE, 2> split_proposal,
                         legate::AccessorRO<double, 3> g,
                         legate::AccessorRO<double, 3> h)
   {
@@ -140,14 +139,11 @@ struct TreeBuilder {
       if (position < 0 || !compute) continue;
       for (int64_t j = 0; j < num_features; j++) {
         auto x_value = X[{i, j, 0}];
-        int bin_idx =
-          std::lower_bound(
-            split_proposal.ptr({j, 0}), split_proposal.ptr({j, samples_per_feature}), x_value) -
-          split_proposal.ptr({j, 0});
+        int bin_idx  = split_proposals.FindBin(x_value, j);
 
-        if (bin_idx < samples_per_feature) {
+        if (bin_idx != SparseSplitProposals<T>::NOT_FOUND) {
           for (int64_t k = 0; k < num_outputs; ++k) {
-            histogram_buffer[{position, j, k, bin_idx}] += GPair{g[{i, 0, k}], h[{i, 0, k}]};
+            histogram_buffer[{position, bin_idx, k}] += GPair{g[{i, 0, k}], h[{i, 0, k}]};
           }
         }
       }
@@ -155,8 +151,8 @@ struct TreeBuilder {
 
     SumAllReduce(
       context,
-      reinterpret_cast<double*>(histogram_buffer.ptr({BinaryTree::LevelBegin(depth), 0, 0, 0})),
-      BinaryTree::NodesInLevel(depth) * num_features * samples_per_feature * num_outputs * 2);
+      reinterpret_cast<double*>(histogram_buffer.ptr({BinaryTree::LevelBegin(depth), 0, 0})),
+      BinaryTree::NodesInLevel(depth) * split_proposals.histogram_size * num_outputs * 2);
     this->Scan(depth, tree);
   }
 
@@ -164,11 +160,12 @@ struct TreeBuilder {
   {
     auto scan_node_histogram = [&](int node_idx) {
       for (int feature = 0; feature < num_features; feature++) {
+        auto [feature_begin, feature_end] = split_proposals.FeatureRange(feature);
         for (int output = 0; output < num_outputs; output++) {
           GPair sum = {0.0, 0.0};
-          for (int bin_idx = 0; bin_idx < samples_per_feature; bin_idx++) {
-            sum += histogram_buffer[{node_idx, feature, output, bin_idx}];
-            histogram_buffer[{node_idx, feature, output, bin_idx}] = sum;
+          for (int bin_idx = feature_begin; bin_idx < feature_end; bin_idx++) {
+            sum += histogram_buffer[{node_idx, bin_idx, output}];
+            histogram_buffer[{node_idx, bin_idx, output}] = sum;
           }
         }
       }
@@ -177,12 +174,12 @@ struct TreeBuilder {
     auto subtract_node_histogram =
       [&](int subtract_node_idx, int scanned_node_idx, int parent_node_idx) {
         for (int feature = 0; feature < num_features; feature++) {
+          auto [feature_begin, feature_end] = split_proposals.FeatureRange(feature);
           for (int output = 0; output < num_outputs; output++) {
-            for (int bin_idx = 0; bin_idx < samples_per_feature; bin_idx++) {
-              auto scanned_sum = histogram_buffer[{scanned_node_idx, feature, output, bin_idx}];
-              auto parent_sum  = histogram_buffer[{parent_node_idx, feature, output, bin_idx}];
-              histogram_buffer[{subtract_node_idx, feature, output, bin_idx}] =
-                parent_sum - scanned_sum;
+            for (int bin_idx = feature_begin; bin_idx < feature_end; bin_idx++) {
+              auto scanned_sum = histogram_buffer[{scanned_node_idx, bin_idx, output}];
+              auto parent_sum  = histogram_buffer[{parent_node_idx, bin_idx, output}];
+              histogram_buffer[{subtract_node_idx, bin_idx, output}] = parent_sum - scanned_sum;
             }
           }
         }
@@ -201,11 +198,7 @@ struct TreeBuilder {
       subtract_node_histogram(subtract_node_idx, histogram_node_idx, parent_id);
     }
   }
-  template <typename TYPE>
-  void PerformBestSplit(int depth,
-                        Tree& tree,
-                        legate::AccessorRO<TYPE, 2> split_proposal,
-                        double alpha)
+  void PerformBestSplit(int depth, Tree& tree, double alpha)
   {
     for (int node_id = BinaryTree::LevelBegin(depth); node_id < BinaryTree::LevelBegin(depth + 1);
          node_id++) {
@@ -213,10 +206,11 @@ struct TreeBuilder {
       int best_feature = -1;
       int best_bin     = -1;
       for (int feature = 0; feature < num_features; feature++) {
-        for (int bin_idx = 0; bin_idx < samples_per_feature; bin_idx++) {
+        auto [feature_begin, feature_end] = split_proposals.FeatureRange(feature);
+        for (int bin_idx = feature_begin; bin_idx < feature_end; bin_idx++) {
           double gain = 0;
           for (int output = 0; output < num_outputs; ++output) {
-            auto [G_L, H_L] = histogram_buffer[{node_id, feature, output, bin_idx}];
+            auto [G_L, H_L] = histogram_buffer[{node_id, bin_idx, output}];
             auto G          = tree.gradient[{node_id, output}];
             auto H          = tree.hessian[{node_id, output}];
             auto G_R        = G - G_L;
@@ -240,7 +234,7 @@ struct TreeBuilder {
         std::vector<double> hessian_left(num_outputs);
         std::vector<double> hessian_right(num_outputs);
         for (int output = 0; output < num_outputs; ++output) {
-          auto [G_L, H_L]        = histogram_buffer[{node_id, best_feature, output, best_bin}];
+          auto [G_L, H_L]        = histogram_buffer[{node_id, best_bin, output}];
           auto G                 = tree.gradient[{node_id, output}];
           auto H                 = tree.hessian[{node_id, output}];
           auto G_R               = G - G_L;
@@ -255,7 +249,7 @@ struct TreeBuilder {
         if (hessian_left[0] <= 0.0 || hessian_right[0] <= 0.0) continue;
         tree.AddSplit(node_id,
                       best_feature,
-                      split_proposal[{best_feature, best_bin}],
+                      split_proposals.split_proposals[{best_bin}],
                       left_leaf,
                       right_leaf,
                       best_gain,
@@ -314,8 +308,8 @@ struct TreeBuilder {
   const int32_t num_features;
   const int32_t num_outputs;
   const int32_t max_nodes;
-  const int32_t samples_per_feature;
-  legate::Buffer<GPair, 4> histogram_buffer;
+  SparseSplitProposals<T> split_proposals;
+  legate::Buffer<GPair, 3> histogram_buffer;
 };
 
 struct build_tree_fn {
@@ -326,7 +320,9 @@ struct build_tree_fn {
     auto [g, g_shape, g_accessor] = GetInputStore<double, 3>(context.input(1).data());
     auto [h, h_shape, h_accessor] = GetInputStore<double, 3>(context.input(2).data());
     auto [split_proposals, split_proposals_shape, split_proposals_accessor] =
-      GetInputStore<T, 2>(context.input(3).data());
+      GetInputStore<T, 1>(context.input(3).data());
+    auto [row_pointers, row_pointers_shape, row_pointers_accessor] =
+      GetInputStore<int32_t, 1>(context.input(4).data());
     EXPECT_DENSE_ROW_MAJOR(X_accessor.accessor, X_shape);
     EXPECT_DENSE_ROW_MAJOR(split_proposals_accessor.accessor, split_proposals_shape);
     auto num_features = X_shape.hi[1] - X_shape.lo[1] + 1;
@@ -336,7 +332,7 @@ struct build_tree_fn {
     EXPECT_AXIS_ALIGNED(1, g_shape, h_shape);
     auto num_outputs = g.shape<3>().hi[2] - g.shape<3>().lo[2] + 1;
     EXPECT_IS_BROADCAST(split_proposals_shape);
-    auto samples_per_feature = split_proposals_shape.hi[1] - split_proposals_shape.lo[1] + 1;
+    EXPECT_IS_BROADCAST(row_pointers_shape);
     EXPECT(g_shape.lo[2] == 0, "Expect all outputs to be present");
 
     // Scalars
@@ -346,20 +342,21 @@ struct build_tree_fn {
 
     Tree tree(max_nodes, num_outputs);
     // Begin building the tree
-    TreeBuilder tree_builder(num_rows, num_features, num_outputs, max_nodes, samples_per_feature);
+    TreeBuilder tree_builder(num_rows,
+                             num_features,
+                             num_outputs,
+                             max_nodes,
+                             SparseSplitProposals<T>(split_proposals_accessor,
+                                                     row_pointers_accessor,
+                                                     num_features,
+                                                     split_proposals_shape.volume()));
     tree_builder.InitialiseRoot(context, tree, g_accessor, h_accessor, g_shape, alpha);
     for (int64_t depth = 0; depth < max_depth; ++depth) {
       tree_builder.UpdatePositions(depth, tree, X_accessor, X_shape);
 
-      tree_builder.ComputeHistogram(depth,
-                                    context,
-                                    tree,
-                                    X_accessor,
-                                    X_shape,
-                                    split_proposals_accessor,
-                                    g_accessor,
-                                    h_accessor);
-      tree_builder.PerformBestSplit(depth, tree, split_proposals_accessor, alpha);
+      tree_builder.ComputeHistogram(
+        depth, context, tree, X_accessor, X_shape, g_accessor, h_accessor);
+      tree_builder.PerformBestSplit(depth, tree, alpha);
     }
 
     WriteTreeOutput(context, tree);

--- a/src/models/tree/build_tree.cc
+++ b/src/models/tree/build_tree.cc
@@ -346,8 +346,8 @@ struct build_tree_fn {
                              num_features,
                              num_outputs,
                              max_nodes,
-                             SparseSplitProposals<T>(split_proposals_accessor,
-                                                     row_pointers_accessor,
+                             SparseSplitProposals<T>(legate::Buffer<T, 1>(),
+                                                     legate::Buffer<int32_t, 1>(),
                                                      num_features,
                                                      split_proposals_shape.volume()));
     tree_builder.InitialiseRoot(context, tree, g_accessor, h_accessor, g_shape, alpha);

--- a/src/models/tree/build_tree.h
+++ b/src/models/tree/build_tree.h
@@ -90,13 +90,13 @@ inline __host__ __device__ GPair operator+(const GPair& a, const GPair& b)
 template <typename T>
 class SparseSplitProposals {
  public:
-  legate::AccessorRO<T, 1> split_proposals;
-  legate::AccessorRO<int32_t, 1> row_pointers;
+  legate::Buffer<T, 1> split_proposals;
+  legate::Buffer<int32_t, 1> row_pointers;
   int32_t num_features;
   int32_t histogram_size;
   static const int NOT_FOUND = -1;
-  SparseSplitProposals(legate::AccessorRO<T, 1> split_proposals,
-                       legate::AccessorRO<int32_t, 1> row_pointers,
+  SparseSplitProposals(legate::Buffer<T, 1> split_proposals,
+                       legate::Buffer<int32_t, 1> row_pointers,
                        int32_t num_features,
                        int32_t histogram_size)
     : split_proposals(split_proposals),


### PR DESCRIPTION
When e.g. feature samples=256 but we have a feature with only values 0,1, do not allocate an entire histogram of 256 bins, instead only 2 bins.