### PR TITLE
declare scipy dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ requires = [
     "cunumeric",
     "legate-core",
     "scikit-learn",
+    "scipy",
     "numpy",
     "typing_extensions",  # Required by legate.core as well.
 ]


### PR DESCRIPTION
Contributes to #115.

This project directly imports `scipy`, e.g. here

https://github.com/rapidsai/legate-boost/blob/900b68826e64cf046bc809d7a77037cc73f1f387/legateboost/objectives.py#L4

But doesn't directly declare its dependency on `scipy`. That hasn't been a problem because it pulls that in transitively via depending on `scikit-learn`, but it really should be declared explicitly:

* to prevent breakages in the (admittedly very unlikely) case where `scikit-learn` makes its `scipy` dependency optional
* to make that dependency more obvious to anyone looking at the package metadata