### PR TITLE
run mypy via pre-commit

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,14 +11,16 @@ on:
       - "branch-*"
       - "main"
 jobs:
-  pre-commit:
+  checks:
     runs-on: ubuntu-latest
+    container:
+      image: rapidsai/ci-conda:latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
+      - uses: actions/checkout@v4
+      - name: Run ci/check_style.sh
+        run: ci/check_style.sh
   build-test:
-    needs: [pre-commit]
+    needs: [checks]
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,7 +11,14 @@ on:
       - "branch-*"
       - "main"
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1
   build-test:
+    needs: [pre-commit]
     defaults:
       run:
         shell: bash -el {0}
@@ -25,15 +32,12 @@ jobs:
     steps:
       - name: Install legate/cunumeric
         run: |
-          mamba install -y -c legate -c conda-forge legate-core=24.06 cunumeric=24.06 build cmake scikit-build scikit-learn hypothesis 'pytest<8' notebook 'numpy<2' mypy openblas
+          mamba install -y -c legate -c conda-forge legate-core=24.06 cunumeric=24.06 build cmake scikit-build scikit-learn hypothesis 'pytest<8' notebook 'numpy<2' openblas
           pip install matplotlib seaborn xgboost
       - name: Checkout legateboost
         uses: actions/checkout@v4
         with:
           lfs: true
-      - name: Type check legateboost
-        run: |
-          mypy ./legateboost --config-file ./setup.cfg --exclude=legateboost/test --exclude=install_info
       - name: Build legateboost
         run: |
           CUDA_ARCH=70\;80 ./build.sh
@@ -81,10 +85,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2
-
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,5 +28,16 @@ repos:
         - id: clang-format
           files: \.(cu|cuh|h|cc|inl)$
           types_or: []
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: 'v1.10.1'
+      hooks:
+        - id: mypy
+          args: [
+              "--config-file=./setup.cfg",
+              "--exclude=legateboost/test",
+              "--exclude=install_info",
+              "./legateboost"
+          ]
+          pass_filenames: false
 default_language_version:
     python: python3

--- a/ci/check_style.sh
+++ b/ci/check_style.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2024, NVIDIA CORPORATION.
+
+set -euo pipefail
+
+# install dependencies, so tools like 'mypy' can look deeper into the code
+conda install \
+    --yes \
+    -c conda-forge \
+    -c legate \
+        cunumeric=24.06 \
+        legate-core=24.06 \
+        numpy \
+        pre-commit \
+        scikit-learn \
+        scipy
+
+git config --global --add safe.directory /opt/legate-boost
+
+# Run pre-commit checks
+pre-commit run --all-files

--- a/contributing.md
+++ b/contributing.md
@@ -42,9 +42,10 @@ The following general principles should be followed when developing legateboost.
     - Do not be afraid to use 64 bit integers for indexing if it means avoiding any possible overflow issues.
 - Avoid optimisation where possible in favour of clear implementation
 - Favour cunumeric implementations where appropriate. e.g. elementwise or matrix operations
-- Use mypy type annotations if at all possible. The typing can be checked by running the following command under the project root:
-```
-mypy ./legateboost --config-file ./setup.cfg --exclude=legateboost/test --exclude=install_info
+- Use type annotations if at all possible. The typing can be checked by running the following command under the project root:
+
+```shell
+pre-commit run mypy --all-files
 ```
 
 ### Performance

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ extras_require = {
         "nbconvert",
         "seaborn",
         "matplotlib",
-        "mypy",
     ]
 }
 


### PR DESCRIPTION
Contributes to #115.

Proposes running `mypy` via `pre-commit`, for the following reasons:

* reduce duplication of `mypy` configuration
* remove a dependency from the `[test]` extra for the package
* standardizes `mypy` version across all the place where those checks are run (to limit "it works on my computer, why is CI broken" types of situations)

As part of this, this PR also proposes running `pre-commit` checks in CI before the other building and testing, on a standard GitHub-hosted `ubuntu-latest` runner, to avoid occupying an NVIDIA-hosted GPU runner for a build that's doomed to fail because of linter errors.

## Notes for Reviewers

Running these checks in the `rapidsai/ci-conda:latest` image and via a script named `ci/check_style.sh` mirrors what is done across most RAPIDS libraries. That'll make it easier to continue integrating CI tools from RAPIDS.