### PR TITLE
WIP: use CMake builtin mechanisms for setting target CUDA architecture(s)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -54,8 +54,10 @@ jobs:
         run: |
           mypy ./legateboost --config-file ./setup.cfg --exclude=legateboost/test --exclude=install_info
       - name: Build legateboost
+        env:
+          CUDAARCHS: '70;80'
         run: |
-          CUDA_ARCH=70\;80 ./build.sh
+          ./build.sh
           python -m build -n --wheel
       - uses: actions/upload-artifact@v3
         with:

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -u -o pipefail
+
+# ensure 'native' is used if CUDAARCHS isn't set
+# (instead of the CMake default which is a specific architecture)
+# ref: https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html
+declare -r CMAKE_CUDA_ARCHITECTURES="${CUDAARCHS:-native}"
 
 legate_root=`python -c 'import legate.install_info as i; from pathlib import Path; print(Path(i.libpath).parent.resolve())'`
 echo "Using Legate at $legate_root"
-cmake -S . -B build -D legate_core_ROOT=$legate_root -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=native
+cmake -S . -B build -D legate_core_ROOT=$legate_root -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}
 cmake --build build -j
 python -m pip install -e .

--- a/contributing.md
+++ b/contributing.md
@@ -16,7 +16,21 @@ legate --module pytest legateboost/test
 
 ## Change default CUDA architectures
 
-Set the environment variable `CUDA_ARCH` according to cmake [CUDA_ARCHITECTURES](https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html) if you are installing with pip. For running cmake directly, the argument `CMAKE_CUDA_ARCHITECTURES` works as well.
+By default, builds here default to `CMAKE_CUDA_ARCHITECTURES=native` (whatever GPU exists on the system where the build is running).
+
+If installing with `pip`, set the `CUDAARCHS` environment variable, as described in the CMake docs ([link](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html)).
+
+```shell
+CUDAARCHS="70;80" \
+    pip install .
+```
+
+For CMake-based builds, pass `CMAKE_CUDA_ARCHITECTURES`.
+
+```shell
+cmake -B build -S . -DCMAKE_CUDA_ARCHITECTURES="70;80"
+cmake --build build -j
+```
 
 ## Pre-commit hooks
 

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,14 @@ import legate.install_info as lg_install_info
 
 legate_dir = Path(lg_install_info.libpath).parent.as_posix()
 
+# ensure 'native' is used if CUDAARCHS isn't set
+# (instead of the CMake default which is a specific architecture)
+# ref: https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html
+cuda_arch = os.getenv("CUDAARCHS", "native")
+
 cmake_flags = [
     f"-Dlegate_core_ROOT:STRING={legate_dir}",
-    "-DCMAKE_CUDA_ARCHITECTURES=native",
+    f"-DCMAKE_CUDA_ARCHITECTURES={cuda_arch}",
 ]
 
 env_cmake_args = os.environ.get("CMAKE_ARGS")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,14 +60,7 @@ target_compile_options(legateboost
               "$<$<COMPILE_LANGUAGE:CUDA>:${LB_CUDA_FLAGS}>"
 )
 
-
-
 if (Legion_USE_CUDA)
-  # CUDA_ARCH environment variable can override the CMAKE_CUDA_ARCHITECTURES
-  if(DEFINED ENV{CUDA_ARCH})
-    message(STATUS "legateboost: CUDA_ARCH=$ENV{CUDA_ARCH}")
-    set_property(TARGET legateboost PROPERTY CUDA_ARCHITECTURES $ENV{CUDA_ARCH} )
-  endif()
   target_compile_definitions(legateboost PRIVATE LEGATEBOOST_USE_CUDA)
 endif()
 


### PR DESCRIPTION
Contributes to #115

As described at https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html, if the target GPU architectures isn't explicitly provided to `CMake`, it falls back to a concrete (but system-and-compiler-specific) version.

To help with that, #81 introduced two things:

* ability to set the target architecture via an environment variable `CUDA_ARCH`
* fallback to `native` (whatever GPU is detected on the system where the build is running)

This proposes preserving that functionality, but in a different way:

* using the environment variable `CUDAARCHS`, which CMake has supported since v3.18 ([docs link](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html)), instead of introducing a custom one
* ensuring that architecture can also be overridden for `pip install`

## Notes for Reviewers

### Benefits of these changes

Reduces complexity in managing CUDA architecture, by reducing the number of paths through which configuration flows to CMake. This will be important when we introduce yet another build pattern (conda builds) here.

### How I tested this

Added code like this at the bottom of the top-level `CMakeLists.txt`.

```cmake
get_target_property(
  REQUESTED_ARCHITECTURES
  legateboost
  CUDA_ARCHITECTURES
)

message(FATAL_ERROR "requested architectures: ${REQUESTED_ARCHITECTURES}")
```

Found the expected behavior for regular CMake builds, `build.sh`, and `pip install`.