### PR TITLE
update some CI versions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -27,7 +27,7 @@ jobs:
     env:
       CONDA_PREFIX: /opt/conda
     container:
-      image: rapidsai/devcontainers:23.10-cpp-cuda11.8-mambaforge-ubuntu22.04
+      image: rapidsai/devcontainers:24.08-cpp-cuda11.8-mambaforge-ubuntu22.04
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
     steps:
@@ -59,7 +59,7 @@ jobs:
         run: |
           ./build.sh
           python -m build -n --wheel
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: legateboost-wheel
           path: dist/legateboost*.whl
@@ -74,7 +74,7 @@ jobs:
         working-directory: docs
         run: |
           make html
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/build
 
@@ -99,4 +99,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Contributes to #115 .

This proposes updating some versions in CI:

* all third-party GitHub actions to their latest versions
* `rapidsai/devcontainers` image *(which most CI tasks here use)* from `23.10` to `24.08` *(the latest)*

This resolves these warnings that can be seen on every CI run ([example build](https://github.com/rapidsai/legate-boost/actions/runs/10077329919)) 

> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/upload-artifact@v3
>
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/deploy-pages@v2
>
> The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "github-pages", "legateboost-wheel".
> Please update your workflow to use v4 of the artifact actions.