### PR TITLE
isolate wheel-building in a shell script, run shellcheck

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -57,8 +57,7 @@ jobs:
         env:
           CUDAARCHS: '70;80'
         run: |
-          ./build.sh
-          python -m build -n --wheel
+          ci/build_wheel.sh
       - uses: actions/upload-artifact@v4
         with:
           name: legateboost-wheel

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+*.a
 build
+*.conda
 dist/
 docs/source/examples
 docs/source/README.md
@@ -11,9 +13,16 @@ legateboost/library.py
 legateboost/install_info.py
 legate_prof*
 .mypy_cache/
+*.o
+*.pyc
 __pycache__/
 .hypothesis
 examples/notebook/*.py
 legion_prof
 benchmark
 benchmark/!*.py
+*.so
+*.tar.bz2
+*.tar.gz
+*.whl
+*.zip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,10 @@ repos:
         -   id: end-of-file-fixer
         -   id: check-yaml
         -   id: check-added-large-files
+    - repo: https://github.com/shellcheck-py/shellcheck-py
+      rev: v0.10.0.1
+      hooks:
+        - id: shellcheck
     - repo: https://github.com/PyCQA/isort
       rev: 5.13.2
       hooks:

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,10 @@ set -e -u -o pipefail
 # ref: https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html
 declare -r CMAKE_CUDA_ARCHITECTURES="${CUDAARCHS:-native}"
 
-legate_root=`python -c 'import legate.install_info as i; from pathlib import Path; print(Path(i.libpath).parent.resolve())'`
+legate_root=$(
+    python -c 'import legate.install_info as i; from pathlib import Path; print(Path(i.libpath).parent.resolve())'
+)
 echo "Using Legate at $legate_root"
-cmake -S . -B build -D legate_core_ROOT=$legate_root -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}
+cmake -S . -B build -Dlegate_core_ROOT="${legate_root}" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES="${CMAKE_CUDA_ARCHITECTURES}"
 cmake --build build -j
 python -m pip install -e .

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -4,6 +4,6 @@ set -e -u -o pipefail
 
 ./build.sh
 python -m build \
-    --no-build-isolation \
+    --no-isolation \
     --wheel \
     --outdir dist

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -4,6 +4,6 @@ set -e -u -o pipefail
 
 ./build.sh
 python -m build \
-    -no-build-isolation \
+    --no-build-isolation \
     --wheel \
     --outdir dist

--- a/ci/build_wheel.sh
+++ b/ci/build_wheel.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+./build.sh
+python -m build \
+    -no-build-isolation \
+    --wheel \
+    --outdir dist


### PR DESCRIPTION
Contributes to #115 

In #126, I'm working on moving the project's packaging metadata to `pyproject.toml`. To make that smaller and easier to review, this proposes some of the smaller auxiliary changes from there:

* putting all the wheel-building logic in a shell script
  - *as is done across most of RAPIDS, e.g. https://github.com/rapidsai/cuml/blob/branch-24.08/ci/build_wheel.sh*
* adding packaging-relevant file extensions to `.gitignore`
* running `shellcheck` in CI, to catch errors in shell scripts