### PR TITLE
update project name to 'legate-boost'

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,4 +1,4 @@
-name: legateboost build/test
+name: legate-boost build/test
 
 concurrency:
   group: ci-on-${{ github.event_name }}-from-${{ github.ref_name }}
@@ -31,7 +31,7 @@ jobs:
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
     steps:
-      - name: Checkout legateboost
+      - name: Checkout legate-boost
         uses: actions/checkout@v4
         with:
           lfs: true
@@ -50,10 +50,10 @@ jobs:
           mamba env update \
             --name base \
             --file /tmp/env.yaml
-      - name: Type check legateboost
+      - name: Type check legate-boost
         run: |
           mypy ./legateboost --config-file ./pyproject.toml --exclude=legateboost/test --exclude=install_info
-      - name: Build legateboost
+      - name: Build legate-boost
         env:
           CUDAARCHS: '70;80'
         run: |
@@ -62,7 +62,7 @@ jobs:
         with:
           name: legateboost-wheel
           path: dist/legateboost*.whl
-      - name: Install legateboost
+      - name: Install legate-boost
         run: |
           python -m pip install --no-deps dist/*.whl
       - name: Run cpu tests
@@ -72,7 +72,7 @@ jobs:
         run: |
           nvidia-smi
           legate --gpus 1 --fbmem 28000 --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0 -k 'not sklearn'
-      - name: Build legateboost docs
+      - name: Build legate-boost docs
         working-directory: docs
         run: |
           make html

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# LegateBoost
+# legate-boost
 
-GBM implementation on Legate. The primary goals of LegateBoost is to provide a state-of-the-art distributed GBM implementation on Legate, capable of running on CPUs or GPUs at supercomputer scale.
+GBM implementation on Legate. The primary goals of `legate-boost` is to provide a state-of-the-art distributed GBM implementation on Legate, capable of running on CPUs or GPUs at supercomputer scale.
 
 [API Documentation](https://rapidsai.github.io/legate-boost)
 
@@ -27,14 +27,17 @@ model = lb.LBRegressor(verbose=1, n_estimators=100, random_state=0, max_depth=2)
 ## Features
 
 ### Probabilistic regression
-Legateboost can learn distributions for continuous data. This is useful in cases where simply predicting the mean does not carry enough information about the training data:
+
+`legate-boost` can learn distributions for continuous data. This is useful in cases where simply predicting the mean does not carry enough information about the training data:
 
 <img src="examples/probabalistic_regression/probabilistic_regression.gif" alt="drawing" width="800"/>
 
 The above example can be found here: [examples/probabilistic_regression](examples/probabalistic_regression/README.md).
 
 ### Batch training
-Legateboost can train on datasets that do not fit into memory by splitting the dataset into batches and training the model with `partial_fit`.
+
+`legate-boost` can train on datasets that do not fit into memory by splitting the dataset into batches and training the model with `partial_fit`.
+
 ```python
 total_estimators = 100
 model = lb.LBRegressor(n_estimators=estimators_per_batch)
@@ -51,7 +54,8 @@ for i in range(total_estimators // estimators_per_batch):
 The above example can be found here: [examples/batch_training](examples/batch_training/README.md).
 
 ### Different model types
-Legateboost supports tree models, linear models, kernel ridge regression models, custom user models and any combinations of these models.
+
+`legate-boost` supports tree models, linear models, kernel ridge regression models, custom user models and any combinations of these models.
 
 The following example shows a model combining linear and decision tree base learners on a synthetic dataset.
 

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e -u -o pipefail
 NUMARGS=$#
 ARGS=$*
 
-HELP="build liblegateboost.so and a 'legateboost' Python wheel, and install that wheel
+HELP="build liblegateboost.so and a 'legate-boost' Python wheel, and install that wheel
 
   $0 [<flag> ...]
 
@@ -46,5 +46,5 @@ if hasArg --editable; then
     PIP_INSTALL_ARGS+=("--editable")
 fi
 
-echo "building legateboost Python package..."
+echo "building legate-boost Python package..."
 python -m pip install "${PIP_INSTALL_ARGS[@]}" .

--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,6 @@
-# Contributing to legateboost
+# Contributing to legate-boost
 
-`legateboost` depends on some libraries that are not easily installable with `pip`.
+`legate-boost` depends on some libraries that are not easily installable with `pip`.
 
 Use `conda` to create a development environment that includes them.
 
@@ -75,7 +75,7 @@ pre-commit run --all-files
 ```
 ## Development principles
 
-The following general principles should be followed when developing legateboost.
+The following general principles should be followed when developing `legate-boost`.
 
 ### Coding style
 
@@ -93,13 +93,13 @@ mypy ./legateboost --config-file ./pyproject.toml --exclude=legateboost/test --e
 ### Performance
 
 - Memory usage is more often a limiting factor than computation time in large distributed training runs. E.g. A proposal that improves runtime by 2x but increases memory usage by 1.5x is likely to be rejected.
-- Legateboost should support CPUs and GPUs as first class citizens.
-- Legateboost will strive for acceptable to good performance on single machine and state-of-the-art performance in a distributed setting.
+- `legate-boost` should support CPUs and GPUs as first class citizens.
+- `legate-boost` will strive for acceptable to good performance on single machine and state-of-the-art performance in a distributed setting.
 - Accepting performance improvements will depend on how maintainable the changes are versus the improvement for a single machine and distributed setting, with a heavier weighting towards the distributed setting.
 - In deciding what level of performance optimisation is appropriate, see the below performance guidelines
-    - Legateboost should be expected to run faster than equivalent python based implementations on a single machine e.g. Sklearn.
-    - Legateboost <em>should not</em> be expected to run faster than highly optimised native implementations on a single machine. e.g. LightGBM/XGBoost.
-    - Legateboost <em>should</em> compete with the above implementions in a distributed setting.
+    - `legate-boost` should be expected to run faster than equivalent python based implementations on a single machine e.g. Sklearn.
+    - `legate-boost` <em>should not</em> be expected to run faster than highly optimised native implementations on a single machine. e.g. LightGBM/XGBoost.
+    - `legate-boost` <em>should</em> compete with the above implementions in a distributed setting.
 
 ### Testing
 
@@ -109,8 +109,10 @@ mypy ./legateboost --config-file ./pyproject.toml --exclude=legateboost/test --e
 
 ### Supported platforms
 
-- Platform support: legateboost will support the same platforms as the legate ecosystem. Legateboost will also support conda or pip following the legate ecosystem.
-- Installation should be as simple as possible. e.g. `pip install legateboost` or `conda install legateboost`.
+- Platform support:
+    - `legate-boost` will support the same platforms as the legate ecosystem.
+    - `legate-boost` will also support conda or pip following the legate ecosystem.
+- Installation should be as simple as possible. e.g. `pip install legate-boost` or `conda install legate-boost`.
 - Dependency minimisation will facilitate the above.
 
 ### Data science considerations
@@ -122,4 +124,6 @@ TODO: review by experts
 
 ### Non-goals
 - Federated learning or privacy preserving machine learning. The literature is not advanced enough to indicate what the best approach is here.
-- External memory. Legateboost will defer data management to legate/legion. Legateboost will not implement its own external memory algorithms, unless the functionality is already implemented in legate.
+- External memory.
+    - `legate-boost` will defer data management to legate/legion.
+    - `legate-boost` will not implement its own external memory algorithms, unless the functionality is already implemented in legate.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "legateboost"
+project = "legate-boost"
 copyright = "2023, NVIDIA"
 author = "NVIDIA"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "legateboost"
+name = "legate-boost"
 version = "0.1"
 authors = [
     {name = "NVIDIA Corporation"},


### PR DESCRIPTION
Contributes to #115.

Clarifies that the project name is `legate-boost` (with a `-`).

As of this PR, this project would have the following spellings.

Installation:

```shell
conda install legate-boost

pip install legate-boost
```

Python:

```python
import legateboost
```

C++

```cpp
namespace legateboost { ...

legateboost::PredictTask::register_variants();
```

Shared library:

```
liblegateboost.so
```

CMake:

```cmake
project(legateboost ...

add_library(legateboost ...
```

## Notes for Reviewers

I searched for these like this:

```shell
git grep -i legateboost
```

I choose to leave unchanged anything that seemed to be a reference to the project in general, not the Python package specifically.

For example:

https://github.com/rapidsai/legate-boost/blob/64871589b060cbdd25615e677c30594db7b03ae8/docs/source/memory.md#L1

https://github.com/rapidsai/legate-boost/blob/64871589b060cbdd25615e677c30594db7b03ae8/legateboost/legateboost.py#L64

Let me know if you think any of those should be changed too.