### PR TITLE
fix docs and wheel publishing

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: legateboost-wheel
-          path: dist/legate-boost*.whl
+          path: dist/legate_boost*.whl
           if-no-files-found: error
       - name: Install legate-boost
         run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -61,7 +61,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: legateboost-wheel
-          path: dist/legateboost*.whl
+          path: dist/legate-boost*.whl
+          if-no-files-found: error
       - name: Install legate-boost
         run: |
           python -m pip install --no-deps dist/*.whl
@@ -78,7 +79,7 @@ jobs:
           make html
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/build
+          path: docs/build/html
 
 
   deploy:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Install legate-boost
         run: |
           python -m pip install --no-deps dist/*.whl
-      - name: Run cpu tests
-        run: |
-          legate --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0
-      - name: Run gpu tests
-        run: |
-          nvidia-smi
-          legate --gpus 1 --fbmem 28000 --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0 -k 'not sklearn'
+      # - name: Run cpu tests
+      #   run: |
+      #     legate --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0
+      # - name: Run gpu tests
+      #   run: |
+      #     nvidia-smi
+      #     legate --gpus 1 --fbmem 28000 --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0 -k 'not sklearn'
       - name: Build legate-boost docs
         working-directory: docs
         run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Install legate-boost
         run: |
           python -m pip install --no-deps dist/*.whl
-      # - name: Run cpu tests
-      #   run: |
-      #     legate --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0
-      # - name: Run gpu tests
-      #   run: |
-      #     nvidia-smi
-      #     legate --gpus 1 --fbmem 28000 --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0 -k 'not sklearn'
+      - name: Run cpu tests
+        run: |
+          legate --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0
+      - name: Run gpu tests
+        run: |
+          nvidia-smi
+          legate --gpus 1 --fbmem 28000 --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0 -k 'not sklearn'
       - name: Build legate-boost docs
         working-directory: docs
         run: |
@@ -85,7 +85,7 @@ jobs:
   deploy:
     needs: build-test
     # only main branch uploads docs
-    #if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -85,7 +85,7 @@ jobs:
   deploy:
     needs: build-test
     # only main branch uploads docs
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    #if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:


### PR DESCRIPTION
Attempts to fix #134.

There are 2 artifact-upload issues in this repo right now:

* the docs site is broken (#134)
* wheels are not getting uploaded (as a result of the file name changing in #133)

This attempts to fix both of those, and makes the use of `actions/artifact-upload` stricter, so it'll raise a loud error on similar configuration issues in the future.
