### PR TITLE
remove setup-python in pre-commit CI job

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
     - uses: pre-commit/action@v3.0.1
 
   build-test:


### PR DESCRIPTION
This proposes removing the use of `actions/setup-python` in the `pre-commit` CI job.

Right now, this repo is running that without specifying a target Python version, resulting in this warning:

> The `python-version` input is not set. The version of Python currently in `PATH` will be used.

Until it becomes a problem, I'm proposing that this repo just use whatever Python version is shipped in the `ubuntu-latest` GitHub-hosted runner VM image. As of this writing, that is 3.12.3 ([list of software pre-installed on ubuntu-latest runner](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)).

### Benefits of this change

* slightly faster builds
* slightly less maintenance burden (no need to update `actions/setup-python` version as that project changes)
* removes a warning in GitHub Actions summaries (reducing the risk that other, more important warnings will be missed)