### PR TITLE
move more testing logic into scripts

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -51,7 +51,7 @@ jobs:
             --file /tmp/env.yaml
       - name: Type check legate-boost
         run: |
-          mypy ./legateboost --config-file ./pyproject.toml --exclude=legateboost/test --exclude=install_info
+          ci/run_mypy.sh
       - name: Build legate-boost
         env:
           CUDAARCHS: '70;80'
@@ -67,11 +67,10 @@ jobs:
           python -m pip install --no-deps dist/*.whl
       - name: Run cpu tests
         run: |
-          legate --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0
+          ci/run_pytests_cpu.sh
       - name: Run gpu tests
         run: |
-          nvidia-smi
-          legate --gpus 1 --fbmem 28000 --sysmem 28000 --module pytest legateboost/test/[!_]**.py -sv --durations=0 -k 'not sklearn'
+          ci/run_pytests_gpu.sh
       - name: Build legate-boost docs
         working-directory: docs
         run: |

--- a/ci/run_mypy.sh
+++ b/ci/run_mypy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# [description]
+#
+#   Run 'mypy' type-checker.
+#
+#   This is intended for use by both CI and local development,
+#   so shouldn't rely on any CI-specific details.
+#
+#   This is done in a separate script instead of via pre-commit because
+#   running it in a non-isolated environment where all of the project's dependencies
+#   are installed allows for more thorough type-checking.
+#
+
+set -e -E -u -o pipefail
+
+mypy \
+    --config-file ./pyproject.toml \
+    --exclude=legateboost/test \
+    --exclude=install_info \
+    ./legateboost

--- a/ci/run_pytests_cpu.sh
+++ b/ci/run_pytests_cpu.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# [description]
+#
+#   Run CPU tests.
+#
+#   This is intended for use by both CI and local development,
+#   so shouldn't rely on any CI-specific details.
+#
+#   Additional arguments passed to this script are passed through to 'pytest'.
+#
+
+set -e -E -u -o pipefail
+
+legate \
+    --sysmem 28000 \
+    --module pytest \
+    legateboost/test/[!_]**.py \
+    -sv \
+    --durations=0 \
+    "${@}"

--- a/ci/run_pytests_gpu.sh
+++ b/ci/run_pytests_gpu.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# [description]
+#
+#   Run GPU tests.
+#
+#   This is intended for use by both CI and local development,
+#   so shouldn't rely on any CI-specific details.
+#
+#   Additional arguments passed to this script are passed through to 'pytest'.
+#
+
+set -e -E -u -o pipefail
+
+nvidia-smi
+
+legate \
+    --gpus 1 \
+    --fbmem 28000 \
+    --sysmem 28000 \
+    --module pytest \
+    legateboost/test/[!_]**.py \
+    -sv \
+    --durations=0 \
+    -k 'not sklearn' \
+    "${@}"

--- a/contributing.md
+++ b/contributing.md
@@ -25,22 +25,13 @@ and install an editable wheel that uses it.
 CPU:
 
 ```shell
-legate \
-    --sysmem 28000 \
-    --module pytest \
-    legateboost/test
+ci/run_pytests_cpu.sh
 ```
 
 GPU:
 
 ```shell
-legate \
-    --gpus 1 \
-    --fbmem 28000 \
-    --sysmem 28000 \
-    --module pytest \
-    legateboost/test/test_estimator.py \
-    -k 'not sklearn'
+ci/run_pytests_gpu.sh
 ```
 
 ## Change default CUDA architectures
@@ -92,8 +83,9 @@ The following general principles should be followed when developing `legate-boos
 - Avoid optimisation where possible in favour of clear implementation
 - Favour cunumeric implementations where appropriate. e.g. elementwise or matrix operations
 - Use mypy type annotations if at all possible. The typing can be checked by running the following command under the project root:
-```
-mypy ./legateboost --config-file ./pyproject.toml --exclude=legateboost/test --exclude=install_info
+
+```shell
+ci/run_mypy.sh
 ```
 
 ### Performance


### PR DESCRIPTION
Contributes to #115.

Some testing details like how to run `mypy` and `pytest` are currently repeated across CI configuration and the documentation. Once conda builds and corresponding tests are added, there will be even more CI jobs that need to run those same commands.

To reduce duplication and unnecessary differences between the way tests are run locally vs. in CI, this proposes moving that logic into scripts in the `ci/` directory.

## Notes for Reviewers

These script names follow conventions in use across RAPIDS, which are roughly like this:

* `ci/run_pytests*.sh` = run tests, without any reliance on CI-specific details (intended to be usable in local development)
* `ci/test_*.sh` = invoke `ci/run_pytests*.sh`, but maybe with other CI-specific details such as creating a dedicated conda environment
  - *(to be introduced in a later PR, like #129)