### PR TITLE
tightly control Python version used in CI

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -29,6 +29,7 @@ jobs:
       image: rapidsai/devcontainers:24.08-cpp-cuda11.8-mambaforge-ubuntu22.04
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
+        PYTHON_VERSION: 3.11
     steps:
       - name: Checkout legate-boost
         uses: actions/checkout@v4
@@ -42,7 +43,7 @@ jobs:
           rapids-dependency-file-generator \
             --output conda \
             --file-key all \
-            --matrix "cuda=${CUDA_VERSION};arch=$(arch)" | tee /tmp/env.yaml
+            --matrix "cuda=${CUDA_VERSION};arch=$(arch);py=${PYTHON_VERSION}" | tee /tmp/env.yaml
 
           # update the current environment (instead of creating a new one), as that
           # persists across all steps

--- a/conda/environments/all_cuda-118.yaml
+++ b/conda/environments/all_cuda-118.yaml
@@ -18,6 +18,7 @@ dependencies:
 - pydata-sphinx-theme
 - pytest<8
 - python-build>=1.2.0
+- python>=3.8,<3.12
 - scikit-build>=0.18.0
 - scikit-learn
 - seaborn

--- a/conda/environments/all_cuda-118.yaml
+++ b/conda/environments/all_cuda-118.yaml
@@ -18,7 +18,7 @@ dependencies:
 - pydata-sphinx-theme
 - pytest<8
 - python-build>=1.2.0
-- python>=3.8,<3.12
+- python=3.11
 - scikit-build>=0.18.0
 - scikit-learn
 - seaborn

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -79,10 +79,10 @@ dependencies:
           - matrix:
               py: "3.11"
             packages:
-              - python=3.11
+              - &latest_python python=3.11
           - matrix:
             packages:
-              - python>=3.8,<3.12
+              - *latest_python
   run:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -8,6 +8,7 @@ files:
       - build
       - build_tools
       - docs
+      - py_version
       - run
       - test
   py_build:
@@ -59,6 +60,29 @@ dependencies:
           - sphinx
           - pydata-sphinx-theme
           - myst-parser
+  py_version:
+    specific:
+      - output_types: conda
+        matrices:
+          - matrix:
+              py: "3.8"
+            packages:
+              - python=3.8
+          - matrix:
+              py: "3.9"
+            packages:
+              - python=3.9
+          - matrix:
+              py: "3.10"
+            packages:
+              - python=3.10
+          - matrix:
+              py: "3.11"
+            packages:
+              - python=3.11
+          - matrix:
+            packages:
+              - python>=3.8,<3.12
   run:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "cunumeric==24.06.*",


### PR DESCRIPTION
Contributes to #115

Today, the environment used for testing in this project's CI does not constrain the Python version used, which means it's determined by whatever the default is in the version of `conda` installed in the testing environment.

Proposes adding entries to `dependencies.yaml` to allow tightly controlling the Python version used in conda environments created from it.

## Notes for Reviewers

The section key `py_version` and selector `py` are conventions used across much of RAPIDS to accomplish this same goal: https://github.com/search?q=org%3Arapidsai%20%22py_version%3A%22&type=code

### How to test this

You can see this in CI logs. For example, from this recent run on `main`: https://github.com/rapidsai/legate-boost/actions/runs/10270837089/job/28419497048

Notice that Python 3.12 is used there:

```text
Pinned packages:
  - python 3.12.*
```

([specific log line](https://github.com/rapidsai/legate-boost/actions/runs/10270837089/job/28419497048#step:5:62))

Even though the container that job is running in has Python 3.10:

```shell
docker run \
  --rm \
  -it rapidsai/devcontainers:24.08-cpp-cuda11.8-mambaforge-ubuntu22.04 \
  bash -c "python --version"

# Python 3.10.4
```