### PR TITLE
WIP: update build.sh, introduce pr-builder workflow

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,6 +11,17 @@ on:
       - "branch-*"
       - "main"
 jobs:
+
+  # group together all jobs that must pass for a PR to be merged
+  # (for use by branch protections)
+  pr-builder:
+    # skip on builds from merges to main
+    if: github.ref != 'refs/heads/main'
+    needs:
+      - pre-commit
+      - build-test
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
+
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/contributing.md
+++ b/contributing.md
@@ -17,7 +17,7 @@ The easiest way to develop is to compile the shared library separately, then bui
 and install an editable wheel that uses it.
 
 ```shell
-./build.sh --editable
+./build.sh legate-boost --editable
 ```
 
 ## Running tests


### PR DESCRIPTION
Contributes to #115

Pulling some more changes off of #129.

Proposes:

* updating `build.sh` such that it doesn't always and unconditionally call `cmake --build` (so it's possible to drive all the compilation through `pip install` install, which is what the conda build process will do)
* introducing the RAPIDS `pr-build` CI workflow:
   - this workflow doesn't run any code... it just holds dependencies on all the things that have to pass for PRs to be merged
   - this is convenient because it means you only have to change the branch protection in the repo one time (to require `pr-builder`), and then as CI jobs are added / removed, you can effectively change the branch protection via code changes, without involving ops

## Notes for Reviewrs

If you agree with adding `pr-builder`, I'll put up an ops request after this asking for the repo settings to be changed so that that workflow has to pass for PRs to be merged.