### PR TITLE
update some CI versions, move docs-building to a script

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,4 +1,4 @@
-name: legate-boost build/test
+name: CI
 
 concurrency:
   group: ci-on-${{ github.event_name }}-from-${{ github.ref_name }}
@@ -8,8 +8,8 @@ on:
   push:
     branches:
       - "pull-request/[0-9]+"
-      - "branch-*"
       - "main"
+
 jobs:
 
   # group together all jobs that must pass for a PR to be merged
@@ -87,16 +87,11 @@ jobs:
         run: |
           ci/run_pytests_gpu.sh
       - name: Build legate-boost docs
-        working-directory: docs
         run: |
-          apt-get update
-          apt-get install --no-install-recommends -y \
-            make
-          make html
+          ci/build_docs.sh
       - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/build/html
-
 
   deploy:
     needs: build-test

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,4 +1,4 @@
-name: CI
+name: legate-boost build/test
 
 concurrency:
   group: ci-on-${{ github.event_name }}-from-${{ github.ref_name }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,11 @@ repos:
       hooks:
             - id: isort
     - repo: https://github.com/psf/black
-      rev: '24.4.2'
+      rev: '24.8.0'
       hooks:
             - id: black
     - repo: https://github.com/PyCQA/flake8
-      rev: '7.1.0'
+      rev: '7.1.1'
       hooks:
             - id: flake8
     - repo: https://github.com/PyCQA/docformatter

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -E -u -o pipefail
+
+rapids-print-env
+
+make -C docs html

--- a/conda/environments/all_cuda-122.yaml
+++ b/conda/environments/all_cuda-122.yaml
@@ -14,6 +14,7 @@ dependencies:
 - legate-core=24.06=*_ucx
 - legate-core==24.06.*
 - libcublas-dev
+- make
 - matplotlib
 - mypy
 - myst-parser
@@ -25,7 +26,7 @@ dependencies:
 - pydata-sphinx-theme
 - pytest<8
 - python-build>=1.2.0
-- python=3.11
+- python=3.12
 - scikit-build>=0.18.0
 - scikit-learn
 - seaborn

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,6 +19,12 @@ files:
       table: build-system
     includes:
       - build
+  py_docs:
+    output: none
+    includes:
+      - docs
+      - py_version
+      - run
   py_run:
     output: pyproject
     pyproject_dir: .
@@ -77,9 +83,12 @@ dependencies:
     common:
       - output_types: [conda, pyproject, requirements]
         packages:
-          - sphinx
-          - pydata-sphinx-theme
           - myst-parser
+          - pydata-sphinx-theme
+          - sphinx
+      - output_types: [conda]
+        packages:
+          - make
   py_version:
     specific:
       - output_types: conda
@@ -99,7 +108,11 @@ dependencies:
           - matrix:
               py: "3.11"
             packages:
-              - &latest_python python=3.11
+              - python=3.11
+          - matrix:
+              py: "3.12"
+            packages:
+              - &latest_python python=3.12
           - matrix:
             packages:
               - *latest_python


### PR DESCRIPTION
Contributes to #115 

This PR has some miscellaneous small CI things that I noticed while working on adding conda builds in #129. Pulling them into a separate PR to make the diff for that PR smaller.

* adding a Python 3.12 entry to `dependencies.yaml`
* updating all `pre-commit` hooks (via `pre-commit autoupdate`)
* moving docs-building code out of CI configs and into a script
  - *(this will become more important in #129 when that logic becomes a bit more involved)*

## Notes for Reviewers

See comments on the diff for reasoning behind other specific changes.