### PR TITLE
Sync with legate TOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ docs/source/_static/examples/
 _skbuild
 *.pyc
 *.egg-info
-legateboost/library.py
 legateboost/install_info.py
 legate_prof*
 .mypy_cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
   )
 endif()
 
-project(legateboost VERSION "${_legateboost_version}" LANGUAGES C CXX CUDA)
+project(legateboost VERSION "${_legateboost_version}" LANGUAGES C CXX)
 
 option(SANITIZE "Build with address sanitizer" OFF)
 
@@ -28,17 +28,58 @@ set(BUILD_SHARED_LIBS ON)
 # Not required. We will build it if not found.
 find_package(legateboost QUIET)
 find_package(legate_core REQUIRED)
+
+if(Legion_USE_CUDA)
+  enable_language(CUDA)
+endif()
+
 find_package(BLAS REQUIRED)
 
-legate_add_cpp_subdirectory(src TARGET legateboost EXPORT legateboost-export)
-
-legate_add_cffi(${CMAKE_SOURCE_DIR}/src/legateboost.h TARGET legateboost)
-legate_python_library_template(legateboost)
-legate_default_python_install(legateboost EXPORT legateboost-export)
-
+add_subdirectory(src)
 
 if (SANITIZE)
   message(STATUS "Adding sanitizer flags")
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
+endif()
+
+include(cmake/legateboost/get_rapids_cmake.cmake)
+legateboost_get_rapids_cmake()
+
+include(cmake/legateboost/generate_install_info.cmake)
+legateboost_generate_install_info(${CMAKE_CURRENT_SOURCE_DIR}/src/legateboost.h TARGET legateboost)
+
+include(cmake/legateboost/add_cffi.cmake)
+legateboost_add_cffi(legateboost)
+
+include(GNUInstallDirs)
+
+rapids_cmake_install_lib_dir(lib_dir)
+
+install(TARGETS legateboost DESTINATION ${lib_dir} EXPORT legateboost-export)
+
+install(DIRECTORY cmake/legateboost/
+        DESTINATION "${lib_dir}/cmake/legateboost" FILES_MATCHING
+        PATTERN "*.cmake")
+
+rapids_export(INSTALL legateboost
+  EXPORT_SET legateboost-export
+  GLOBAL_TARGETS legateboost
+  NAMESPACE legate::)
+
+# build export targets
+rapids_export(BUILD legateboost
+  EXPORT_SET legateboost-export
+  GLOBAL_TARGETS legateboote
+  NAMESPACE legate::)
+
+if(SKBUILD)
+  add_library(legateboost_python INTERFACE)
+  add_library(legate::legateboost_python ALIAS legateboost_python)
+  target_link_libraries(legateboost_python INTERFACE legate::core legate::legateboost)
+
+  install(TARGETS legateboost_python DESTINATION ${lib_dir} EXPORT legateboost-export)
+
+  rapids_export(INSTALL legateboost_python EXPORT_SET legateboost-export
+    GLOBAL_TARGETS legateboost_python NAMESPACE legate::)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,9 +49,6 @@ legateboost_get_rapids_cmake()
 include(cmake/legateboost/generate_install_info.cmake)
 legateboost_generate_install_info(${CMAKE_CURRENT_SOURCE_DIR}/src/legateboost.h TARGET legateboost)
 
-include(cmake/legateboost/add_cffi.cmake)
-legateboost_add_cffi(legateboost)
-
 include(GNUInstallDirs)
 
 rapids_cmake_install_lib_dir(lib_dir)

--- a/cmake/legateboost/add_cffi.cmake
+++ b/cmake/legateboost/add_cffi.cmake
@@ -1,0 +1,116 @@
+#=============================================================================
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#=============================================================================
+
+include_guard(GLOBAL)
+
+function(legateboost_add_cffi py_path)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "add_cffi")
+
+  string(REPLACE "/" "_" target "${py_path}")
+  string(REPLACE "/" "." py_import_path "${py_path}")
+
+  set(fn_library "${CMAKE_CURRENT_SOURCE_DIR}/${py_path}/library.py")
+  set(file_template
+      [=[
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+from legate.core import (
+    get_legate_runtime,
+)
+import os
+import platform
+from typing import Any
+from ctypes import CDLL, RTLD_GLOBAL
+
+# TODO: Make sure we only have one ffi instance?
+import cffi
+
+def dlopen_no_autoclose(ffi: Any, lib_path: str) -> Any:
+    # Use an already-opened library handle, which cffi will convert to a
+    # regular FFI object (using the definitions previously added using
+    # ffi.cdef), but will not automatically dlclose() on collection.
+    lib = CDLL(lib_path, mode=RTLD_GLOBAL)
+    return ffi.dlopen(ffi.cast("void *", lib._handle))
+
+class UserLibrary:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.shared_object: Any = None
+
+        shared_lib_path = self.get_shared_library()
+        if shared_lib_path is not None:
+            ffi = cffi.FFI()
+            header = self.get_c_header()
+            if header is not None:
+                ffi.cdef(header)
+            # Don't use ffi.dlopen(), because that will call dlclose()
+            # automatically when the object gets collected, thus removing
+            # symbols that may be needed when destroying C++ objects later
+            # (e.g. vtable entries, which will be queried for virtual
+            # destructors), causing errors at shutdown.
+            shared_lib = dlopen_no_autoclose(ffi, shared_lib_path)
+            self.initialize(shared_lib)
+            callback_name = self.get_registration_callback()
+            callback = getattr(shared_lib, callback_name)
+            callback()
+        else:
+            self.initialize(None)
+
+
+    @property
+    def cffi(self) -> Any:
+        return self.shared_object
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_shared_library(self) -> str:
+        from @py_import_path@.install_info import libpath
+        return os.path.join(libpath, f"lib@target@{self.get_library_extension()}")
+
+    def get_c_header(self) -> str:
+        from @py_import_path@.install_info import header
+
+        return header
+
+    def get_registration_callback(self) -> str:
+        return "@target@_perform_registration"
+
+    def initialize(self, shared_object: Any) -> None:
+        self.shared_object = shared_object
+
+    def destroy(self) -> None:
+        pass
+
+    @staticmethod
+    def get_library_extension() -> str:
+        os_name = platform.system()
+        if os_name == "Linux":
+            return ".so"
+        elif os_name == "Darwin":
+            return ".dylib"
+        raise RuntimeError(f"unknown platform {os_name!r}")
+
+user_lib = UserLibrary("@target@")
+user_context = get_legate_runtime().find_library(user_lib.get_name())
+]=])
+  string(CONFIGURE "${file_template}" file_content @ONLY)
+  file(WRITE "${fn_library}" "${file_content}")
+endfunction()

--- a/cmake/legateboost/generate_install_info.cmake
+++ b/cmake/legateboost/generate_install_info.cmake
@@ -1,0 +1,116 @@
+#=============================================================================
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#=============================================================================
+
+include_guard(GLOBAL)
+
+function(legateboost_generate_install_info header)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "generate_install_info")
+
+  set(options)
+  set(one_value_args TARGET PY_PATH)
+  set(multi_value_args)
+  cmake_parse_arguments(LEGATE_OPT "${options}" "${one_value_args}" "${multi_value_args}"
+                        ${ARGN})
+
+  # determine full Python path
+  if(NOT DEFINED LEGATE_OPT_PY_PATH)
+    set(py_path "${CMAKE_CURRENT_SOURCE_DIR}/${LEGATE_OPT_TARGET}")
+  elseif(IS_ABSOLUTE LEGATE_OPT_PY_PATH)
+    set(py_path "${LEGATE_OPT_PY_PATH}")
+  else()
+    set(py_path "${CMAKE_CURRENT_SOURCE_DIR}/${LEGATE_OPT_PY_PATH}")
+  endif()
+
+  # abbreviate for the function below
+  set(target ${LEGATE_OPT_TARGET})
+  set(install_info_in
+      [=[
+from pathlib import Path
+
+def get_libpath():
+    import os, sys, platform
+    join = os.path.join
+    exists = os.path.exists
+    dirname = os.path.dirname
+    cn_path = dirname(dirname(__file__))
+    so_ext = {
+        "": "",
+        "Java": ".jar",
+        "Linux": ".so",
+        "Darwin": ".dylib",
+        "Windows": ".dll"
+    }[platform.system()]
+
+    def find_lib(libdir):
+        target = f"lib@target@{so_ext}*"
+        search_path = Path(libdir)
+        matches = [m for m in search_path.rglob(target)]
+        if matches:
+          return matches[0].parent
+        return None
+
+    return (
+        find_lib("@libdir@") or
+        find_lib(join(dirname(dirname(dirname(cn_path))), "lib")) or
+        find_lib(join(dirname(dirname(sys.executable)), "lib")) or
+        ""
+    )
+
+libpath: str = get_libpath()
+
+header: str = """
+  @header@
+  void @target@_perform_registration();
+"""
+]=])
+  set(install_info_py_in ${CMAKE_CURRENT_BINARY_DIR}/legate_${target}/install_info.py.in)
+  set(install_info_py ${py_path}/install_info.py)
+  file(WRITE ${install_info_py_in} "${install_info_in}")
+
+  set(generate_script_content
+      [=[
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER}
+        -E
+        -P @header@
+      ECHO_ERROR_VARIABLE
+      OUTPUT_VARIABLE header
+      COMMAND_ERROR_IS_FATAL ANY
+    )
+    configure_file(
+        @install_info_py_in@
+        @install_info_py@
+        @ONLY)
+  ]=])
+
+  set(generate_script ${CMAKE_CURRENT_BINARY_DIR}/gen_install_info.cmake)
+  # I think this is a bug? It is complaining "Invalid form descriminator", which I believe
+  # refers to the @ONLY. But that is valid for this function...
+  #
+  # cmake-lint: disable=E1126
+  file(CONFIGURE OUTPUT ${generate_script} CONTENT "${generate_script_content}" @ONLY)
+
+  if(DEFINED ${target}_BUILD_LIBDIR)
+    # this must have been imported from an existing editable build
+    set(libdir ${${target}_BUILD_LIBDIR})
+  else()
+    # libraries are built in a common spot
+    set(libdir ${CMAKE_BINARY_DIR}/legate_${target})
+  endif()
+  add_custom_target("${target}_generate_install_info_py" ALL
+                    COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                            -Dtarget=${target} -Dlibdir=${libdir} -P ${generate_script}
+                            OUTPUT ${install_info_py}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    COMMENT "Generating install_info.py"
+                    DEPENDS ${header})
+endfunction()

--- a/cmake/legateboost/get_rapids_cmake.cmake
+++ b/cmake/legateboost/get_rapids_cmake.cmake
@@ -1,0 +1,37 @@
+#=============================================================================
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#=============================================================================
+
+include_guard(GLOBAL)
+
+macro(legateboost_get_rapids_cmake)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "get_rapids_cmake")
+
+  if(NOT rapids-cmake-version)
+    # default
+    set(rapids-cmake-version 24.08)
+    set(rapids-cmake-sha "3cc764f287a6f3caeee5dd1c96c24b1710d4cdf1")
+  endif()
+
+  if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    file(DOWNLOAD
+      https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${rapids-cmake-version}/RAPIDS.cmake
+      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+  endif()
+  include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+  include(rapids-cmake)
+  include(rapids-cpm)
+  include(rapids-cuda)
+  include(rapids-export)
+  include(rapids-find)
+
+  list(POP_BACK CMAKE_MESSAGE_CONTEXT)
+endmacro()

--- a/src/cpp_utils/cpp_utils.h
+++ b/src/cpp_utils/cpp_utils.h
@@ -131,9 +131,8 @@ void SumAllReduce(legate::TaskContext context, T* x, int count)
   std::vector<T> data(items_per_rank * num_ranks);
   std::copy(x, x + count, data.begin());
   std::vector<T> recvbuf(items_per_rank * num_ranks);
-  auto result =
-    legate::comm::coll::collAlltoall(data.data(), recvbuf.data(), items_per_rank, type, comm_ptr);
-  EXPECT(result == legate::comm::coll::CollSuccess, "CPU communicator failed.");
+
+  legate::comm::coll::collAlltoall(data.data(), recvbuf.data(), items_per_rank, type, comm_ptr);
 
   // Sum partials
   std::vector<T> partials(items_per_rank, 0.0);
@@ -141,9 +140,8 @@ void SumAllReduce(legate::TaskContext context, T* x, int count)
     for (size_t i = 0; i < num_ranks; i++) { partials[j] += recvbuf[i * items_per_rank + j]; }
   }
 
-  result = legate::comm::coll::collAllgather(
+  legate::comm::coll::collAllgather(
     partials.data(), recvbuf.data(), items_per_rank, type, comm_ptr);
-  EXPECT(result == legate::comm::coll::CollSuccess, "CPU communicator failed.");
   std::copy(recvbuf.begin(), recvbuf.begin() + count, x);
 }
 

--- a/src/legate_library.h
+++ b/src/legate_library.h
@@ -22,8 +22,8 @@ struct Registry {
 
 template <typename T, int ID>
 struct Task : public legate::LegateTask<T> {
-  using Registrar              = Registry;
-  static constexpr int TASK_ID = ID;
+  using Registrar               = Registry;
+  static constexpr auto TASK_ID = legate::LocalTaskID{ID};
 };
 
 }  // namespace legateboost

--- a/src/mapper.cc
+++ b/src/mapper.cc
@@ -21,8 +21,6 @@ namespace legateboost {
 
 LegateboostMapper::LegateboostMapper() {}
 
-void LegateboostMapper::set_machine(const legate::mapping::MachineQueryInterface* /*machine*/) {}
-
 legate::mapping::TaskTarget LegateboostMapper::task_target(
   const legate::mapping::Task& /*task*/, const std::vector<legate::mapping::TaskTarget>& options)
 {

--- a/src/mapper.h
+++ b/src/mapper.h
@@ -30,7 +30,6 @@ class LegateboostMapper : public legate::mapping::Mapper {
 
   // Legate mapping functions
  public:
-  virtual void set_machine(const legate::mapping::MachineQueryInterface* machine) override;
   virtual legate::mapping::TaskTarget task_target(
     const legate::mapping::Task& task,
     const std::vector<legate::mapping::TaskTarget>& options) override;

--- a/src/models/tree/build_tree.cc
+++ b/src/models/tree/build_tree.cc
@@ -320,7 +320,7 @@ struct TreeBuilder {
         if (left_sum[0].hess <= 0.0 || right_sum[0].hess <= 0.0) continue;
         tree.AddSplit(node_id,
                       best_feature,
-                      split_proposals.split_proposals[{best_bin}],
+                      split_proposals.split_proposals[legate::coord_t{best_bin}],
                       left_leaf,
                       right_leaf,
                       best_gain,

--- a/src/models/tree/build_tree.h
+++ b/src/models/tree/build_tree.h
@@ -134,8 +134,8 @@ class SparseSplitProposals {
 #else
   int FindBin(T x, int feature) const
   {
-    auto feature_row_begin = row_pointers[feature];
-    auto feature_row_end   = row_pointers[feature + 1];
+    auto feature_row_begin = legate::coord_t{row_pointers[feature]};
+    auto feature_row_end   = legate::coord_t{row_pointers[feature + 1]};
     auto ptr               = std::lower_bound(
       split_proposals.ptr(feature_row_begin), split_proposals.ptr(feature_row_end), x);
     if (ptr == split_proposals.ptr(feature_row_end)) return NOT_FOUND;


### PR DESCRIPTION
Bring `legate-boost` up to speed with TOT of legate.core.

- Replace the `legate` cmake functions, just inline them and bring them into `legate-boost` directly.
- Fix some compilation errors.