### PR TITLE
set specific GPU architectures for builds

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -11,6 +11,8 @@ on:
       - "main"
 
 env:
+  # CUDA architectures to build for
+  CUDAARCHS: "all-major"
   # where conda-build puts files it creates
   RAPIDS_CONDA_BLD_OUTPUT_DIR: /tmp/conda-bld-output
   # where jobs that download conda packages store the local channel

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: pre-commit/action@v3.0.1
+    # - uses: pre-commit/action@v3.0.1
 
   conda-python-build:
     needs:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    # - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@v3.0.1
 
   conda-python-build:
     needs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,9 @@ repos:
       hooks:
             - id: flake8
     - repo: https://github.com/PyCQA/docformatter
-      rev: 'v1.7.5'
+      # commit from https://github.com/PyCQA/docformatter/pull/287
+      # TODO: switch to a proper release once that change is released
+      rev: '06907d0267368b49b9180eed423fae5697c1e909'
       hooks:
             - id: docformatter
     - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -34,7 +36,7 @@ repos:
           files: \.(cu|cuh|h|cc|inl)$
           types_or: []
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.15.0
+      rev: v1.15.1
       hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,10 @@ repos:
       rev: v0.10.0.1
       hooks:
         - id: shellcheck
+    - repo: https://github.com/PyCQA/isort
+      rev: 5.13.2
+      hooks:
+            - id: isort
     - repo: https://github.com/psf/black
       rev: '24.10.0'
       hooks:
@@ -35,4 +39,4 @@ repos:
         - id: rapids-dependency-file-generator
           args: ["--clean"]
 default_language_version:
-  python: python3
+    python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,10 +11,6 @@ repos:
       rev: v0.10.0.1
       hooks:
         - id: shellcheck
-    - repo: https://github.com/PyCQA/isort
-      rev: 5.13.2
-      hooks:
-            - id: isort
     - repo: https://github.com/psf/black
       rev: '24.10.0'
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.6.0
+      rev: v5.0.0
       hooks:
         -   id: trailing-whitespace
         -   id: end-of-file-fixer
@@ -16,7 +16,7 @@ repos:
       hooks:
             - id: isort
     - repo: https://github.com/psf/black
-      rev: '24.8.0'
+      rev: '24.10.0'
       hooks:
             - id: black
     - repo: https://github.com/PyCQA/flake8
@@ -28,15 +28,15 @@ repos:
       hooks:
             - id: docformatter
     - repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: 'v18.1.8'  # Use the sha / tag you want to point at
+      rev: 'v19.1.1'  # Use the sha / tag you want to point at
       hooks:
         - id: clang-format
           files: \.(cu|cuh|h|cc|inl)$
           types_or: []
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.14.0
+      rev: v1.15.0
       hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]
 default_language_version:
-    python: python3
+  python: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ Documentation = "https://rapidsai.github.io/legate-boost"
 Repository = "https://github.com/rapidsai/legate-boost"
 License = "https://github.com/rapidsai/legate-boost/blob/main/LICENSE"
 
+[tool.scikit-build.build]
+verbose = true
+
 [tool.setuptools.dynamic]
 version = {file = "legateboost/VERSION"}
 


### PR DESCRIPTION
Contributes to #115

While inspecting the size of the conda packages, I was surprised to see that they were tiny (2.5MB for the GPU variant on Python 12). I investigated that, and realized that in CI builds, `legate-boost` is not currently targeting a specific set of GPU architectures.

It's falling back to `native`. Since builds are done on runners without a GPU, that means the packages are being built for whatever the single default target architecture is in the version of CMake getting pulled in ([CMake docs on that](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_ARCHITECTURES.html#variable:CMAKE_CUDA_ARCHITECTURES)).

This PR proposes matching `legate` and `cunumeric`'s behavior, setting `CUDAARCHS="all-major"`. @RAMitchell @trivialfis if you'd prefer to hard-code a specific set of architectures like `80;86;90` or similar, let me know.

## Notes for Reviewers

Bad (good?) timing... as I opened this, `pre-commit` 4.0 came out, breaking some of our configurations here that were relying on hooks that were incompatible with that version. `pre-commit`-related changes that you see in the diff are to fix that.

Mainly:

* updating all hooks to their latest versions
* pinning `docformatter` to a specific unreleased commit, to get the fixes from https://github.com/PyCQA/docformatter/pull/287