### PR TITLE
fix image rendering in docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,8 +24,8 @@ html: Makefile
 	@mkdir -p "$(SOURCEDIR)/_static/examples"
 	@find "$(SOURCEDIR)/examples" -type f \( -name '*.png' -o -name '*.gif' \) -exec cp '{}' "$(SOURCEDIR)/_static/examples" \;
 	@# ensure image links in the example READMEs point to the static-files directory in the site source
-	@find "$(SOURCEDIR)/examples" -type f -name '*.md' -exec sed -i -e 's|img src="|img src="/_static/examples/|g' '{}' \;
-	@sed -i -E 's|img src="examples/[A-Za-z_\-]+/|img src="/_static/examples/|g' "$(SOURCEDIR)/README.md"
+	@find "$(SOURCEDIR)/examples" -type f -name '*.md' -exec sed -i -e 's|img src="|img src="../../_static/examples/|g' '{}' \;
+	@sed -i -E 's|img src="examples/[A-Za-z_\-]+/|img src="_static/examples/|g' "$(SOURCEDIR)/README.md"
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new


### PR DESCRIPTION
Fixes #150

I think this will fix the rendering of images in the docs site. See https://github.com/rapidsai/legate-boost/issues/150#issuecomment-2405981059.

In short... I thought I'd fixed this in #123, but that used some absolute paths that worked in local testing but not in the hosted site.

Fixes:

* using relative paths in image links (`ref="_source/{path}`, not `ref="/_source/{path}"`)
* adding a leading `../../` to links on example pages like https://rapidsai.github.io/legate-boost/examples/kernel_ridge_regression/README.html, to account for the fact that those are nested deeper in the site

## Notes for Reviewers

### How I tested this

```shell
# build + install the library
./build.sh legate-boost --editable

# build the docs
make -C docs clean html

# host the docs
python -m http.server \
    -d ./docs/build/html \
    1456
```

Then navigated to `<ip>:1456` and clicked around. Saw the images render correctly on both the `Getting Started` page and down in example pages.