### PR TITLE
Update to Legate 24.09 nightlies

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -51,9 +51,9 @@ jobs:
       - pre-commit
     strategy:
       fail-fast: false
-      # available legate-core and cunumeric packages:
+      # available legate and cunumeric packages:
       #
-      #   * https://anaconda.org/legate/legate-core
+      #   * https://anaconda.org/legate/legate
       #   * https://anaconda.org/legate/cunumeric
       #
       # Valid set of RAPIDS ci-conda image tags:
@@ -129,7 +129,7 @@ jobs:
       - conda-python-build
     strategy:
       fail-fast: false
-      # As of the last time this was updated, legate-core / cunumeric packages were published for only:
+      # As of the last time this was updated, legate / cunumeric packages were published for only:
       #
       #  * architectures: amd64 only
       #  * CUDA: >=12.2

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ docs/source/_static/examples/
 _skbuild
 *.pyc
 *.egg-info
-legateboost/library.py
 legateboost/install_info.py
 legate_prof*
 .mypy_cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
   )
 endif()
 
-project(legateboost VERSION "${_legateboost_version}" LANGUAGES C CXX CUDA)
+project(legateboost VERSION "${_legateboost_version}" LANGUAGES C CXX)
 
 option(SANITIZE "Build with address sanitizer" OFF)
 
@@ -27,18 +27,57 @@ set(BUILD_SHARED_LIBS ON)
 # Look for an existing C++ editable build
 # Not required. We will build it if not found.
 find_package(legateboost QUIET)
-find_package(legate_core REQUIRED)
+find_package(legate REQUIRED)
+
+if(Legion_USE_CUDA)
+  enable_language(CUDA)
+endif()
+
 find_package(BLAS REQUIRED)
-
-legate_add_cpp_subdirectory(src TARGET legateboost EXPORT legateboost-export)
-
-legate_add_cffi(${CMAKE_SOURCE_DIR}/src/legateboost.h TARGET legateboost)
-legate_python_library_template(legateboost)
-legate_default_python_install(legateboost EXPORT legateboost-export)
-
 
 if (SANITIZE)
   message(STATUS "Adding sanitizer flags")
   add_compile_options(-fsanitize=address)
   add_link_options(-fsanitize=address)
+endif()
+
+include(cmake/legateboost/get_rapids_cmake.cmake)
+legateboost_get_rapids_cmake()
+
+add_subdirectory(src)
+
+include(cmake/legateboost/generate_install_info.cmake)
+legateboost_generate_install_info(${CMAKE_CURRENT_SOURCE_DIR}/src/legateboost.h TARGET legateboost)
+
+include(GNUInstallDirs)
+
+rapids_cmake_install_lib_dir(lib_dir)
+
+install(TARGETS legateboost DESTINATION ${lib_dir} EXPORT legateboost-export)
+
+install(DIRECTORY cmake/legateboost/
+        DESTINATION "${lib_dir}/cmake/legateboost" FILES_MATCHING
+        PATTERN "*.cmake")
+
+rapids_export(INSTALL legateboost
+  EXPORT_SET legateboost-export
+  GLOBAL_TARGETS legateboost
+  NAMESPACE legate::)
+
+# build export targets
+rapids_export(BUILD legateboost
+  EXPORT_SET legateboost-export
+  GLOBAL_TARGETS legateboote
+  NAMESPACE legate::)
+
+if(SKBUILD)
+  add_library(legateboost_python INTERFACE)
+  # NOTE(seberg): Had a local error with the below, but not sure if it is needed:
+  # add_library(legate::legateboost_python ALIAS legateboost_python)
+  target_link_libraries(legateboost_python INTERFACE legate::legate legate::legateboost)
+
+  install(TARGETS legateboost_python DESTINATION ${lib_dir} EXPORT legateboost-export)
+
+  rapids_export(INSTALL legateboost_python EXPORT_SET legateboost-export
+    GLOBAL_TARGETS legateboost_python NAMESPACE legate::)
 endif()

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ model = lb.LBRegressor(base_models=(lb.models.KRR(sigma=0.5), lb.models.Tree(max
 
 ## Installation
 
-If you already have `cunumeric` and `legate-core` installed, run the following:
+If you already have `cunumeric` and `legate` installed, run the following:
 
 ```shell
 pip install \

--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ if hasArg liblegateboost || hasArg --editable; then
     )
     echo "Using Legate at '${legate_root}'"
 
-    cmake -S . -B build -Dlegate_core_ROOT="${legate_root}" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES="${CMAKE_CUDA_ARCHITECTURES}"
+    cmake -S . -B build -Dlegate_ROOT="${legate_root}" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_ARCHITECTURES="${CMAKE_CUDA_ARCHITECTURES}"
     cmake --build build -j
     echo "done building liblegateboost"
 fi

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -33,6 +33,7 @@ rapids-mamba-retry install \
   --name docs-env \
   --channel "${RAPIDS_LOCAL_CONDA_CHANNEL}" \
   --channel legate \
+  --channel legate/label/experimental \
   --channel conda-forge \
   "legate-boost=${LEGATEBOOST_VERSION}"
 

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,6 +11,7 @@ CONDA_OVERRIDE_CUDA="${RAPIDS_CUDA_VERSION}" \
 LEGATEBOOST_PACKAGE_VERSION=$(head -1 ./VERSION) \
 rapids-conda-retry mambabuild \
     --channel legate \
+    --channel legate/label/experimental \
     --channel conda-forge \
     --channel nvidia \
     --no-force-upload \

--- a/ci/run_pytests_cpu.sh
+++ b/ci/run_pytests_cpu.sh
@@ -14,10 +14,13 @@
 
 set -e -E -u -o pipefail
 
+# Go into test folder to not not import source package
+cd legateboost/test
+
 legate \
     --sysmem 28000 \
     --module pytest \
-    legateboost/test/ \
+    . \
     -sv \
     --durations=0 \
     "${@}"

--- a/ci/run_pytests_gpu.sh
+++ b/ci/run_pytests_gpu.sh
@@ -16,12 +16,15 @@ set -e -E -u -o pipefail
 
 nvidia-smi
 
+# Go into package folder to not import source package
+cd legateboost/test
+
 legate \
     --gpus 1 \
     --fbmem 28000 \
     --sysmem 28000 \
     --module pytest \
-    legateboost/test \
+    . \
     -sv \
     --durations=0 \
     -k 'not sklearn' \

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -38,5 +38,6 @@ rapids-mamba-retry install \
   --name test-env \
   --channel "${RAPIDS_LOCAL_CONDA_CHANNEL}" \
   --channel legate \
+  --channel legate/label/experimental \
   --channel conda-forge \
     legate-boost

--- a/ci/test_python_gpu.sh
+++ b/ci/test_python_gpu.sh
@@ -10,4 +10,4 @@ source ./ci/test_python_common.sh
 
 # run the GPU tests
 rapids-logger "Running tests"
-./ci/run_pytests_cpu.sh
+./ci/run_pytests_gpu.sh

--- a/cmake/legateboost/generate_install_info.cmake
+++ b/cmake/legateboost/generate_install_info.cmake
@@ -1,0 +1,116 @@
+#=============================================================================
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#=============================================================================
+
+include_guard(GLOBAL)
+
+function(legateboost_generate_install_info header)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "generate_install_info")
+
+  set(options)
+  set(one_value_args TARGET PY_PATH)
+  set(multi_value_args)
+  cmake_parse_arguments(LEGATE_OPT "${options}" "${one_value_args}" "${multi_value_args}"
+                        ${ARGN})
+
+  # determine full Python path
+  if(NOT DEFINED LEGATE_OPT_PY_PATH)
+    set(py_path "${CMAKE_CURRENT_SOURCE_DIR}/${LEGATE_OPT_TARGET}")
+  elseif(IS_ABSOLUTE LEGATE_OPT_PY_PATH)
+    set(py_path "${LEGATE_OPT_PY_PATH}")
+  else()
+    set(py_path "${CMAKE_CURRENT_SOURCE_DIR}/${LEGATE_OPT_PY_PATH}")
+  endif()
+
+  # abbreviate for the function below
+  set(target ${LEGATE_OPT_TARGET})
+  set(install_info_in
+      [=[
+from pathlib import Path
+
+def get_libpath():
+    import os, sys, platform
+    join = os.path.join
+    exists = os.path.exists
+    dirname = os.path.dirname
+    cn_path = dirname(dirname(__file__))
+    so_ext = {
+        "": "",
+        "Java": ".jar",
+        "Linux": ".so",
+        "Darwin": ".dylib",
+        "Windows": ".dll"
+    }[platform.system()]
+
+    def find_lib(libdir):
+        target = f"lib@target@{so_ext}*"
+        search_path = Path(libdir)
+        matches = [m for m in search_path.rglob(target)]
+        if matches:
+          return matches[0].parent
+        return None
+
+    return (
+        find_lib("@libdir@") or
+        find_lib(join(dirname(dirname(dirname(cn_path))), "lib")) or
+        find_lib(join(dirname(dirname(sys.executable)), "lib")) or
+        ""
+    )
+
+libpath: str = get_libpath()
+
+header: str = """
+  @header@
+  void @target@_perform_registration();
+"""
+]=])
+  set(install_info_py_in ${CMAKE_CURRENT_BINARY_DIR}/legate_${target}/install_info.py.in)
+  set(install_info_py ${py_path}/install_info.py)
+  file(WRITE ${install_info_py_in} "${install_info_in}")
+
+  set(generate_script_content
+      [=[
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER}
+        -E
+        -P @header@
+      ECHO_ERROR_VARIABLE
+      OUTPUT_VARIABLE header
+      COMMAND_ERROR_IS_FATAL ANY
+    )
+    configure_file(
+        @install_info_py_in@
+        @install_info_py@
+        @ONLY)
+  ]=])
+
+  set(generate_script ${CMAKE_CURRENT_BINARY_DIR}/gen_install_info.cmake)
+  # I think this is a bug? It is complaining "Invalid form descriminator", which I believe
+  # refers to the @ONLY. But that is valid for this function...
+  #
+  # cmake-lint: disable=E1126
+  file(CONFIGURE OUTPUT ${generate_script} CONTENT "${generate_script_content}" @ONLY)
+
+  if(DEFINED ${target}_BUILD_LIBDIR)
+    # this must have been imported from an existing editable build
+    set(libdir ${${target}_BUILD_LIBDIR})
+  else()
+    # libraries are built in a common spot
+    set(libdir ${CMAKE_BINARY_DIR}/legate_${target})
+  endif()
+  add_custom_target("${target}_generate_install_info_py" ALL
+                    COMMAND ${CMAKE_COMMAND} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                            -Dtarget=${target} -Dlibdir=${libdir} -P ${generate_script}
+                            OUTPUT ${install_info_py}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    COMMENT "Generating install_info.py"
+                    DEPENDS ${header})
+endfunction()

--- a/cmake/legateboost/get_rapids_cmake.cmake
+++ b/cmake/legateboost/get_rapids_cmake.cmake
@@ -1,0 +1,37 @@
+#=============================================================================
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+#=============================================================================
+
+include_guard(GLOBAL)
+
+macro(legateboost_get_rapids_cmake)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "get_rapids_cmake")
+
+  if(NOT rapids-cmake-version)
+    # default
+    set(rapids-cmake-version 24.08)
+    set(rapids-cmake-sha "3cc764f287a6f3caeee5dd1c96c24b1710d4cdf1")
+  endif()
+
+  if(NOT EXISTS ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+    file(DOWNLOAD
+      https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-${rapids-cmake-version}/RAPIDS.cmake
+      ${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+  endif()
+  include(${CMAKE_BINARY_DIR}/RAPIDS.cmake)
+  include(rapids-cmake)
+  include(rapids-cpm)
+  include(rapids-cuda)
+  include(rapids-export)
+  include(rapids-find)
+
+  list(POP_BACK CMAKE_MESSAGE_CONTEXT)
+endmacro()

--- a/conda/environments/all_cuda-122.yaml
+++ b/conda/environments/all_cuda-122.yaml
@@ -2,6 +2,7 @@
 # To make changes, edit ../../dependencies.yaml and run `rapids-dependency-file-generator`.
 channels:
 - legate
+- legate/label/experimental
 - conda-forge
 - nvidia
 dependencies:
@@ -9,9 +10,9 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version>=12.2
-- cunumeric==24.06.*,>=24.06.01
+- cunumeric==24.09.*,>=0.0.0.dev0
 - hypothesis
-- legate-core==24.06.*,>=24.06.01
+- legate==24.09.*,>=0.0.0.dev0
 - libcublas-dev
 - make
 - matplotlib

--- a/conda/recipes/legate-boost/conda_build_config.yaml
+++ b/conda/recipes/legate-boost/conda_build_config.yaml
@@ -19,11 +19,11 @@ cuda_compiler:
 cuda11_compiler:
   - nvcc
 
-# match the legate-core / cunumeric pattern of publishing
+# match the legate / cunumeric pattern of publishing
 # CPU-only and GPU-only packages for every variant
 gpu_enabled:
   - true
   - false
 
 legate_version:
-  - =24.06.*,>=24.06.01
+  - "=24.09.*,>=0.0.0.dev0"

--- a/conda/recipes/legate-boost/meta.yaml
+++ b/conda/recipes/legate-boost/meta.yaml
@@ -13,7 +13,7 @@
 #  '*_cpu' for CPU-only
 #  '*_gpu' for systems with CUDA
 #
-# this mirrors the approach used by cunumeric / legate-core
+# this mirrors the approach used by cunumeric / legate
 # (though as of 24.06, they do not append a '*_gpu' to the build string for GPU packages)
 {% if gpu_enabled == "true" %}
   {% set gpu_enabled_bool = true %}
@@ -80,12 +80,12 @@ requirements:
     {% if gpu_enabled_bool %}
     - cuda-version ={{ cuda_version }}
     - cuda-cudart-dev
-    - cunumeric {{ legate_version }}
-    - legate-core {{ legate_version }}
+    - cunumeric {{ legate_version }} =*_gpu
+    - legate {{ legate_version }} =*_gpu
     - libcublas-dev
     {% else %}
     - cunumeric {{ legate_version }} =*_cpu
-    - legate-core {{ legate_version }} =*_cpu
+    - legate {{ legate_version }} =*_cpu
     {% endif %}
     - openblas
     - python
@@ -100,17 +100,17 @@ requirements:
     # cuda-version is used to constrain __cuda
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
     - __cuda
-    - cunumeric {{ legate_version }}
+    - cunumeric {{ legate_version }} =*_gpu
     {% else %}
     - cunumeric {{ legate_version }} =*_cpu
     {% endif %}
-    # Relying on run_exports from legate-core to pin an appropriate range of versions and
+    # Relying on run_exports from legate to pin an appropriate range of versions and
     # GPU vs. CPU selector.
     #
-    # legate-core uses {{ pin_subpackage(name, min_pin="x.x.x", max_pin="x.x.x") }}, which means
-    # that if legate-boost builds against, say, legate-core=24.06.0 and then a legate-core=24.06.1 is
+    # legate uses {{ pin_subpackage(name, min_pin="x.x.x", max_pin="x.x.x") }}, which means
+    # that if legate-boost builds against, say, legate=24.06.0 and then a legate=24.06.1 is
     # released, a new legate-boost would be required.
-    - legate-core
+    - legate
     - numpy
     - scikit-learn
     - typing-extensions>=4.0

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -47,6 +47,7 @@ files:
       - test
 channels:
   - legate
+  - legate/label/experimental
   - conda-forge
   - nvidia
 dependencies:
@@ -60,7 +61,7 @@ dependencies:
       - output_types: [conda, pyproject, requirements]
         packages:
           - cmake>=3.24.0,!=3.30.0
-          - &legate_core legate-core==24.06.*,>=24.06.01
+          - &legate legate==24.09.*,>=0.0.0.dev0
           - ninja>=1.11.1.1
           - scikit-build>=0.18.0
           - setuptools>=70.0
@@ -122,8 +123,8 @@ dependencies:
           - typing-extensions>=4.0
       - output_types: [conda, pyproject, requirements]
         packages:
-          - cunumeric==24.06.*,>=24.06.01
-          - *legate_core
+          - cunumeric==24.09.*,>=0.0.0.dev0
+          - *legate
   test:
     common:
       - output_types: [conda, pyproject, requirements]

--- a/legateboost/library.py
+++ b/legateboost/library.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+#                         All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+import os
+import platform
+from ctypes import CDLL, RTLD_GLOBAL
+from typing import Any
+
+import cffi
+
+from legate.core import get_legate_runtime
+
+
+def dlopen_no_autoclose(ffi: Any, lib_path: str) -> Any:
+    # Use an already-opened library handle, which cffi will convert to a
+    # regular FFI object (using the definitions previously added using
+    # ffi.cdef), but will not automatically dlclose() on collection.
+    lib = CDLL(lib_path, mode=RTLD_GLOBAL)
+    return ffi.dlopen(ffi.cast("void *", lib._handle))
+
+
+class UserLibrary:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.shared_object: Any = None
+
+        shared_lib_path = self.get_shared_library()
+        if shared_lib_path is not None:
+            ffi = cffi.FFI()
+            header = self.get_c_header()
+            if header is not None:
+                ffi.cdef(header)
+            # Don't use ffi.dlopen(), because that will call dlclose()
+            # automatically when the object gets collected, thus removing
+            # symbols that may be needed when destroying C++ objects later
+            # (e.g. vtable entries, which will be queried for virtual
+            # destructors), causing errors at shutdown.
+            shared_lib = dlopen_no_autoclose(ffi, shared_lib_path)
+            self.initialize(shared_lib)
+            callback_name = self.get_registration_callback()
+            callback = getattr(shared_lib, callback_name)
+            callback()
+        else:
+            self.initialize(None)
+
+    @property
+    def cffi(self) -> Any:
+        return self.shared_object
+
+    def get_name(self) -> str:
+        return self.name
+
+    def get_shared_library(self) -> str:
+        from .install_info import libpath
+
+        return os.path.join(libpath, f"liblegateboost{self.get_library_extension()}")
+
+    def get_c_header(self) -> str:
+        from .install_info import header
+
+        return header
+
+    def get_registration_callback(self) -> str:
+        return "legateboost_perform_registration"
+
+    def initialize(self, shared_object: Any) -> None:
+        self.shared_object = shared_object
+
+    def destroy(self) -> None:
+        pass
+
+    @staticmethod
+    def get_library_extension() -> str:
+        os_name = platform.system()
+        if os_name == "Linux":
+            return ".so"
+        elif os_name == "Darwin":
+            return ".dylib"
+        raise RuntimeError(f"unknown platform {os_name!r}")
+
+
+user_lib = UserLibrary("legateboost")
+user_context = get_legate_runtime().find_library(user_lib.get_name())

--- a/legateboost/test/test_examples.py
+++ b/legateboost/test/test_examples.py
@@ -59,9 +59,15 @@ def test_notebooks(path):
 
 
 def test_benchmark(benchmark_dir):
+    # Current legate 24.09.dev has issues with overriding legate config
+    # from the legate call.  So have to unset `LEGATE_CONFIG`.
+    env = os.environ.copy()
+    del env["LEGATE_CONFIG"]
+
     subprocess.run(
         "legate --cpus 2 scaling.py --nrows 100 --ncols 5 --niter 2",
         shell=True,
         check=True,
         cwd=benchmark_dir,
+        env=env,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cmake>=3.24.0,!=3.30.0",
-    "legate-core==24.06.*,>=24.06.01",
+    "legate==24.09.*,>=0.0.0.dev0",
     "ninja>=1.11.1.1",
     "scikit-build>=0.18.0",
     "setuptools>=70.0",
@@ -24,8 +24,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "cunumeric==24.06.*,>=24.06.01",
-    "legate-core==24.06.*,>=24.06.01",
+    "cunumeric==24.09.*,>=0.0.0.dev0",
+    "legate==24.09.*,>=0.0.0.dev0",
     "numpy",
     "scikit-learn",
     "typing-extensions>=4.0",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ legate_dir = Path(lg_install_info.libpath).parent.as_posix()
 cuda_arch = os.getenv("CUDAARCHS", "native")
 
 cmake_flags = [
-    f"-Dlegate_core_ROOT:STRING={legate_dir}",
+    f"-Dlegate_ROOT:STRING={legate_dir}",
     f"-DCMAKE_CUDA_ARCHITECTURES={cuda_arch}",
 ]
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,4 +75,4 @@ target_include_directories(legateboost
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(legateboost PRIVATE legate::core BLAS::BLAS $<TARGET_NAME_IF_EXISTS:NCCL::NCCL> $<TARGET_NAME_IF_EXISTS:CUDA::cublas>)
+target_link_libraries(legateboost PRIVATE legate::legate BLAS::BLAS $<TARGET_NAME_IF_EXISTS:NCCL::NCCL> $<TARGET_NAME_IF_EXISTS:CUDA::cublas>)

--- a/src/cpp_utils/cpp_utils.cuh
+++ b/src/cpp_utils/cpp_utils.cuh
@@ -18,8 +18,7 @@
 
 #include "legate.h"
 #include "cpp_utils.h"
-#include "core/cuda/cuda.h"
-#include "core/cuda/stream_pool.h"
+#include "legate/cuda/cuda.h"
 #include <nccl.h>
 
 namespace legateboost {
@@ -132,7 +131,7 @@ template <typename F, int OpCode>
 void UnaryOpTask<F, OpCode>::gpu_variant(legate::TaskContext context)
 {
   auto const& in          = context.input(0);
-  auto stream             = legate::cuda::StreamPool::get_stream_pool().get_stream();
+  auto stream             = context.get_task_stream();
   auto thrust_alloc       = ThrustAllocator(legate::Memory::GPU_FB_MEM);
   auto thrust_exec_policy = DEFAULT_POLICY(thrust_alloc).on(stream);
   legate::dim_dispatch(in.dim(), DispatchDimOp{}, context, in, thrust_exec_policy);

--- a/src/cpp_utils/cpp_utils.h
+++ b/src/cpp_utils/cpp_utils.h
@@ -16,8 +16,8 @@
 
 #pragma once
 #include "legate_library.h"
-#include <core/type/type_info.h>
-#include "core/comm/coll.h"
+#include <legate/type/type_info.h>
+#include "legate/comm/coll.h"
 #include <thrust/for_each.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/execution_policy.h>  // for host
@@ -131,9 +131,8 @@ void AllReduce(legate::TaskContext context, T* x, int count, OpT op)
   std::vector<T> data(items_per_rank * num_ranks);
   std::copy(x, x + count, data.begin());
   std::vector<T> recvbuf(items_per_rank * num_ranks);
-  auto result =
-    legate::comm::coll::collAlltoall(data.data(), recvbuf.data(), items_per_rank, type, comm_ptr);
-  EXPECT(result == legate::comm::coll::CollSuccess, "CPU communicator failed.");
+
+  legate::comm::coll::collAlltoall(data.data(), recvbuf.data(), items_per_rank, type, comm_ptr);
 
   // Sum partials
   std::vector<T> partials(items_per_rank, 0.0);
@@ -143,9 +142,8 @@ void AllReduce(legate::TaskContext context, T* x, int count, OpT op)
     }
   }
 
-  result = legate::comm::coll::collAllgather(
+  legate::comm::coll::collAllgather(
     partials.data(), recvbuf.data(), items_per_rank, type, comm_ptr);
-  EXPECT(result == legate::comm::coll::CollSuccess, "CPU communicator failed.");
   std::copy(recvbuf.begin(), recvbuf.begin() + count, x);
 }
 

--- a/src/legate_library.h
+++ b/src/legate_library.h
@@ -22,8 +22,8 @@ struct Registry {
 
 template <typename T, int ID>
 struct Task : public legate::LegateTask<T> {
-  using Registrar              = Registry;
-  static constexpr int TASK_ID = ID;
+  using Registrar               = Registry;
+  static constexpr auto TASK_ID = legate::LocalTaskID{ID};
 };
 
 }  // namespace legateboost

--- a/src/mapper.cc
+++ b/src/mapper.cc
@@ -21,8 +21,6 @@ namespace legateboost {
 
 LegateboostMapper::LegateboostMapper() {}
 
-void LegateboostMapper::set_machine(const legate::mapping::MachineQueryInterface* /*machine*/) {}
-
 legate::mapping::TaskTarget LegateboostMapper::task_target(
   const legate::mapping::Task& /*task*/, const std::vector<legate::mapping::TaskTarget>& options)
 {

--- a/src/mapper.h
+++ b/src/mapper.h
@@ -30,7 +30,6 @@ class LegateboostMapper : public legate::mapping::Mapper {
 
   // Legate mapping functions
  public:
-  virtual void set_machine(const legate::mapping::MachineQueryInterface* machine) override;
   virtual legate::mapping::TaskTarget task_target(
     const legate::mapping::Task& task,
     const std::vector<legate::mapping::TaskTarget>& options) override;

--- a/src/models/nn/build_nn.h
+++ b/src/models/nn/build_nn.h
@@ -17,7 +17,6 @@
 #include "../../cpp_utils/cpp_utils.h"
 #include "legate_library.h"
 #include "legateboost.h"
-#include "core/cuda/stream_pool.h"
 
 namespace legateboost {
 

--- a/src/models/tree/build_tree.cc
+++ b/src/models/tree/build_tree.cc
@@ -320,7 +320,7 @@ struct TreeBuilder {
         if (left_sum[0].hess <= 0.0 || right_sum[0].hess <= 0.0) continue;
         tree.AddSplit(node_id,
                       best_feature,
-                      split_proposals.split_proposals[best_bin],
+                      split_proposals.split_proposals[legate::coord_t{best_bin}],
                       left_leaf,
                       right_leaf,
                       best_gain,

--- a/src/models/tree/build_tree.cu
+++ b/src/models/tree/build_tree.cu
@@ -17,7 +17,7 @@
 #include "legateboost.h"
 #include "../../cpp_utils/cpp_utils.h"
 #include "../../cpp_utils/cpp_utils.cuh"
-#include "core/comm/coll.h"
+#include "legate/comm/coll.h"
 #include "build_tree.h"
 #include <numeric>
 
@@ -902,7 +902,7 @@ struct build_tree_fn {
     auto seed          = context.scalars().at(4).value<int>();
     auto dataset_rows  = context.scalars().at(5).value<int64_t>();
 
-    auto stream             = legate::cuda::StreamPool::get_stream_pool().get_stream();
+    auto stream             = context.get_task_stream();
     auto thrust_alloc       = ThrustAllocator(legate::Memory::GPU_FB_MEM);
     auto thrust_exec_policy = DEFAULT_POLICY(thrust_alloc).on(stream);
 

--- a/src/models/tree/build_tree.h
+++ b/src/models/tree/build_tree.h
@@ -134,8 +134,8 @@ class SparseSplitProposals {
 #else
   int FindBin(T x, int feature) const
   {
-    auto feature_row_begin = row_pointers[feature];
-    auto feature_row_end   = row_pointers[feature + 1];
+    auto feature_row_begin = legate::coord_t{row_pointers[feature]};
+    auto feature_row_end   = legate::coord_t{row_pointers[feature + 1]};
     auto ptr               = std::lower_bound(
       split_proposals.ptr(feature_row_begin), split_proposals.ptr(feature_row_end), x);
     if (ptr == split_proposals.ptr(feature_row_end)) return NOT_FOUND;

--- a/src/models/tree/predict.cu
+++ b/src/models/tree/predict.cu
@@ -15,7 +15,7 @@
  */
 #include "legate_library.h"
 #include "legateboost.h"
-#include "core/utilities/dispatch.h"
+#include "legate/utilities/dispatch.h"
 #include "../../cpp_utils/cpp_utils.cuh"
 #include "../../cpp_utils/cpp_utils.h"
 #include "predict.h"
@@ -67,7 +67,7 @@ struct predict_fn {
       }
     };
 
-    auto stream = legate::cuda::StreamPool::get_stream_pool().get_stream();
+    auto stream = context.get_task_stream();
     LaunchN(X_shape.hi[0] - X_shape.lo[0] + 1, stream, prediction_lambda);
 
     CHECK_CUDA_STREAM(stream);

--- a/src/special/special.h
+++ b/src/special/special.h
@@ -16,9 +16,9 @@
 
 #include <cstdint>                              // for int32_t
 #include <type_traits>                          // for is_same_v
-#include <legate/core/task/task_context.h>      // for TaskContext
-#include <legate/core/task/exception.h>         // for TaskException
-#include <legate/core/data/physical_array.h>    // for PhysicalArray
+#include <legate/task/task_context.h>           // for TaskContext
+#include <legate/task/exception.h>              // for TaskException
+#include <legate/data/physical_array.h>         // for PhysicalArray
 #include "legateboost.h"                        // for ERF
 #include "legate_library.h"                     // for Task
 #include <thrust/iterator/counting_iterator.h>  // for make_counting_iterator

--- a/src/utils/gather.cu
+++ b/src/utils/gather.cu
@@ -39,7 +39,7 @@ struct gather_fn {
     EXPECT_AXIS_ALIGNED(1, X_shape, split_proposals_shape);
     auto n_features = split_proposals_shape.hi[1] - split_proposals_shape.lo[1] + 1;
 
-    auto stream = legate::cuda::StreamPool::get_stream_pool().get_stream();
+    auto stream = context.get_task_stream();
 
     // we can retrieve sample ids via argument(host) or legate_store(device)
     const int64_t* sample_row_ptr;


### PR DESCRIPTION
This updates to the nightlies based on Jacobs work (i.e. most of the cmake changes and the larger part of the non-stream related C changes).

A slightly bigger change is that there is now a warning for the stream pool API, so we have to pass through the stream more explicitly.

Locally there is a test failing because `legate --cpus 2` thinks that `--cpus` are passed twice.  Let's see, the question will be whether we can just remove it (using the default of 4 cpus probably).