### PR TITLE
Work around possible mypy 1.12.0 regression

### DIFF
--- a/legateboost/utils.py
+++ b/legateboost/utils.py
@@ -25,7 +25,11 @@ class PickleCunumericMixin:
     def __setstate__(self, state: dict[str, Any]) -> None:
         def replace(data: Any) -> None:
             if isinstance(data, (dict, list)):
-                for k, v in data.items() if isinstance(data, dict) else enumerate(data):
+                # Note: mypy 1.12.0 required iter() around data.items() to pass
+                items = (
+                    iter(data.items()) if isinstance(data, dict) else enumerate(data)
+                )
+                for k, v in items:
                     if isinstance(v, np.ndarray):
                         data[k] = cn.asarray(v)
                     replace(v)


### PR DESCRIPTION
~Hopefully, the issue will just go away with mypy 1.12.1. Should fix current general CI failures.~

Pinning isn't nice, so instead, do a harmless code work-around.

---

CI is failing right now claiming that `dict.items()` has no `__next__()`, which seems like this bug: https://github.com/Project-MONAI/MONAI/pull/8145/commits/1893375e8ec5cdd52c99d431e607feb7dbd80802

Block-listing mypy 1.12.0 specifically, seemed like a good guess.


EDIT: Well, that was not actually a mypy issue.  I opened a proper issue.