### PR TITLE
gitignore more files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,13 @@ legate_prof*
 *.o
 *.pyc
 __pycache__/
+.pytest_cache/
 .hypothesis
 examples/notebook/*.py
 legion_prof
 benchmark
 benchmark/!*.py
+.ruff_cache/
 *.so
 *.tar.bz2
 *.tar.gz

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@ repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v5.0.0
       hooks:
-        -   id: trailing-whitespace
-        -   id: end-of-file-fixer
-        -   id: check-yaml
-            exclude: '^conda/recipes/.*meta\.yaml$'
-        -   id: check-added-large-files
+        - id: trailing-whitespace
+        - id: end-of-file-fixer
+        - id: check-yaml
+          exclude: '^conda/recipes/.*meta\.yaml$'
+        - id: check-added-large-files
     - repo: https://github.com/shellcheck-py/shellcheck-py
       rev: v0.10.0.1
       hooks:
@@ -14,23 +14,23 @@ repos:
     - repo: https://github.com/PyCQA/isort
       rev: 5.13.2
       hooks:
-            - id: isort
+        - id: isort
     - repo: https://github.com/psf/black
       rev: '24.10.0'
       hooks:
-            - id: black
+        - id: black
     - repo: https://github.com/PyCQA/flake8
       rev: '7.1.1'
       hooks:
-            - id: flake8
+        - id: flake8
     - repo: https://github.com/PyCQA/docformatter
       # commit from https://github.com/PyCQA/docformatter/pull/287
       # TODO: switch to a proper release once that change is released
       rev: '06907d0267368b49b9180eed423fae5697c1e909'
       hooks:
-            - id: docformatter
+        - id: docformatter
     - repo: https://github.com/pre-commit/mirrors-clang-format
-      rev: 'v19.1.1'  # Use the sha / tag you want to point at
+      rev: 'v19.1.2'  # Use the sha / tag you want to point at
       hooks:
         - id: clang-format
           files: \.(cu|cuh|h|cc|inl)$


### PR DESCRIPTION
This just has minor dev changes, things I noticed while working on other PRs here.

* adds more static analyzer cache directories to `.gitignore`
* updates all pre-commit hook versions, via `pre-commit autoupdate`
* aligns the formatting of all pre-commit hooks (this is totally just a personal style preference, but the mix of indentations was bothering me haha)