### PR TITLE
ensure tags actually trigger builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ on:
       - "release/v[0-9][0-9].[0-9][0-9].[0-9][0-9]"
     # run on pushes of any tags
     tags:
+      - "*"
   # run by clicking buttons in the GitHub Actions UI
   workflow_dispatch:
 


### PR DESCRIPTION
Contributes to #115

I just tried pushing a tag like `v24.08.00` onto the latest commit on `main` to check that it triggered a build. It did not 🙃 

Re-read https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags, and I guess we have to provide the pattern `*` to say "run on all new tags".

> *"The patterns defined in branches and tags are evaluated against the Git ref's name.*

This fixes that.

## Notes for Reviewers

Once I test and see that this (hopefully) works, I'll put up a similar change in `legate-dataframe`.