### PR TITLE
pin to specific version in test and docs builds

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -37,7 +37,7 @@ rapids-mamba-retry install \
   --channel legate \
   --channel legate/label/experimental \
   --channel conda-forge \
-  "legate-boost=${LEGATEBOOST_VERSION}=*_cpu*"
+  "legate-boost=${LEGATEBOOST_VERSION}"
 
 rapids-print-env
 

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -6,6 +6,7 @@ set -e -E -u -o pipefail
 # shellcheck disable=SC1091
 . /opt/conda/etc/profile.d/conda.sh
 
+rapids-generate-version > ./VERSION
 LEGATEBOOST_VERSION=$(rapids-version)
 
 rapids-print-env

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -6,6 +6,8 @@ set -e -E -u -o pipefail
 # shellcheck disable=SC1091
 . /opt/conda/etc/profile.d/conda.sh
 
+LEGATEBOOST_VERSION=$(rapids-version)
+
 rapids-print-env
 
 rapids-dependency-file-generator \
@@ -34,7 +36,7 @@ rapids-mamba-retry install \
   --channel legate \
   --channel legate/label/experimental \
   --channel conda-forge \
-  "legate-boost=*=*_cpu*"
+  "legate-boost=${LEGATEBOOST_VERSION}=*_cpu*"
 
 rapids-print-env
 

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -13,6 +13,8 @@ set -e -E -u -o pipefail
 # shellcheck disable=SC1091
 . /opt/conda/etc/profile.d/conda.sh
 
+LEGATEBOOST_VERSION=$(rapids-version)
+
 rapids-print-env
 
 rapids-dependency-file-generator \
@@ -40,4 +42,4 @@ rapids-mamba-retry install \
   --channel legate \
   --channel legate/label/experimental \
   --channel conda-forge \
-    legate-boost
+    "legate-boost=${LEGATEBOOST_VERSION}"

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -13,6 +13,7 @@ set -e -E -u -o pipefail
 # shellcheck disable=SC1091
 . /opt/conda/etc/profile.d/conda.sh
 
+rapids-generate-version > ./VERSION
 LEGATEBOOST_VERSION=$(rapids-version)
 
 rapids-print-env


### PR DESCRIPTION
Contributes to #115

To test the release workflow, I did this kind of weird thing where. I pushed a tag `v24.08.00` when there was already an "earlier" tag `v24.09.00.dev` in the repo.

That all worked fine... but pulled in the wrong version in the docs build. Because `legate-boost` is unpinned here:

https://github.com/rapidsai/legate-boost/blob/4151942e87472abf4483a85d8422a06deb4728f0/ci/build_docs.sh#L30-L37

`conda` chose one with the highest version. That was `24.09.00.dev3`, even for a workflow run that had produced `24.08.00`. Oops.

This fixes that.