### PR TITLE
only update docs site on tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,11 @@ on:
       - "*"
   # run by clicking buttons in the GitHub Actions UI
   workflow_dispatch:
+    inputs:
+      deploy-docs:
+        description: 'Update the docs site?'
+        required: true
+        type: boolean
 
 jobs:
   conda-python-build:
@@ -30,8 +35,10 @@ jobs:
   docs-build:
     needs:
       - conda-python-build
+    if: github.event_name == "tag" || github.event_name == "workflow_dispatch"
     uses: ./.github/workflows/docs-build.yaml
     with:
       script: "ci/build_docs.sh"
-      deploy: true
+      # only deploy docs on tag pushes or when someone manually runs the workflow
+      deploy: ${{ github.event_name == "tag" }} || ${{ inputs.deploy_docs == true }}
     secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,6 @@ jobs:
   docs-build:
     needs:
       - conda-python-build
-    if: github.event_name == "tag" || github.event_name == "workflow_dispatch"
     uses: ./.github/workflows/docs-build.yaml
     with:
       script: "ci/build_docs.sh"


### PR DESCRIPTION
Contributes to #115

In https://github.com/rapidsai/ops/issues/3582 (private link, sorry) we've reached the conclusion that having 2 GitHub Pages deployments from the same commit doesn't work. This means that when a commit is tagged as a stable release, a new docs deployment switching to the stable version number (e.g. `24.08.02`) doesn't work ("succeeds" in CI, but the docs are not updated).

To get around that for now, this proposes not deploying docs on pushes of new commits. As of this PR, the docs site will only be updated under the following conditions:

* push a new tag
* manually trigged the `build` workflow from the GitHub UI and choose `deploy_docs = true` from the drop-down menu