### PR TITLE
fix docs-deploy condition

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,5 +39,5 @@ jobs:
     with:
       script: "ci/build_docs.sh"
       # only deploy docs on tag pushes or when someone manually runs the workflow
-      deploy: ${{ github.event_name == "tag" }} || ${{ inputs.deploy_docs == true }}
+      deploy: ${{ github.event_name == "tag" || inputs.deploy_docs == true }}
     secrets: inherit


### PR DESCRIPTION
Contributes to #115

Follow-up to #178.

Fixes this error observed when I merged #178:

> The workflow is not valid. .github/workflows/build.yaml (Line: 42, Col: 15): Unexpected symbol: '"tag"'. Located at position 22 within expression: github.event_name == "tag"

([build link](https://github.com/rapidsai/legate-boost/actions/runs/11671846480))

Compound conditions for GitHub Actions stuff need to all be inside a single enclosing `${{ }}`. sorry 😅 