### PR TITLE
Define python API more strictly

### DIFF
--- a/examples/custom_objective.py
+++ b/examples/custom_objective.py
@@ -3,7 +3,7 @@ import legateboost as lb
 
 
 class MyMetric(lb.BaseMetric):
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         return cn.sqrt(((y - pred) ** 2 * w).sum() / w.sum())
 
     def name(self):

--- a/legateboost/__init__.py
+++ b/legateboost/__init__.py
@@ -1,28 +1,5 @@
-from .legateboost import LBClassifier, LBRegressor
-from .metrics import (
-    BaseMetric,
-    ExponentialMetric,
-    GammaDevianceMetric,
-    LogLossMetric,
-    MSEMetric,
-    NormalCRPSMetric,
-    NormalLLMetric,
-    GammaLLMetric,
-    QuantileMetric,
-)
-from .objectives import (
-    BaseObjective,
-    ExponentialObjective,
-    GammaDevianceObjective,
-    GammaObjective,
-    LogLossObjective,
-    NormalObjective,
-    QuantileObjective,
-    SquaredErrorObjective,
-)
-from .callbacks import (
-    TrainingCallback,
-    EarlyStopping,
-)
-from .utils import mod_col_by_idx, pick_col_by_idx, set_col_by_idx
+from .legateboost import *
+from .metrics import *
+from .objectives import *
+from .callbacks import *
 from ._version import __version__

--- a/legateboost/callbacks.py
+++ b/legateboost/callbacks.py
@@ -6,6 +6,8 @@ import numpy as np
 from .legateboost import EvalResult, LBBase
 from .metrics import metrics
 
+__all__ = ["TrainingCallback", "EarlyStopping"]
+
 
 class TrainingCallback(ABC):
     """Interface for training callback."""
@@ -100,11 +102,11 @@ class EarlyStopping(TrainingCallback):
     ) -> bool:
         def maximize(new: float, best: float) -> bool:
             """New score should be greater than the old one."""
-            return np.greater(new - self._min_delta, best)
+            return bool(np.greater(new - self._min_delta, best))
 
         def minimize(new: float, best: float) -> bool:
             """New score should be lesser than the old one."""
-            return np.greater(best - self._min_delta, new)
+            return bool(np.greater(best - self._min_delta, new))
 
         if metrics[metric].minimize():
             improve_op = minimize

--- a/legateboost/input_validation.py
+++ b/legateboost/input_validation.py
@@ -1,9 +1,11 @@
-from typing import Any
+from typing import Any, List
 
 import numpy as np
 import scipy.sparse as sp
 
 import cunumeric as cn
+
+__all__: List[str] = []
 
 
 def check_sample_weight(sample_weight: Any, n: int) -> cn.ndarray:

--- a/legateboost/legateboost.py
+++ b/legateboost/legateboost.py
@@ -450,6 +450,11 @@ class LBBase(BaseEstimator, PickleCunumericMixin):
         return pred
 
     def dump_models(self) -> str:
+        """Dumps the models in the current instance to a string.
+
+        Returns:
+            str: A string representation of the models.
+        """
         check_is_fitted(self, "is_fitted_")
         text = "init={}\n".format(self.model_init_)
         for m in self.models_:

--- a/legateboost/legateboost.py
+++ b/legateboost/legateboost.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 
 EvalResult: TypeAlias = dict[str, dict[str, list[float]]]
 
+__all__ = ["LBBase", "LBClassifier", "LBRegressor"]
+
 
 class LBBase(BaseEstimator, PickleCunumericMixin):
     def __init__(

--- a/legateboost/legateboost.py
+++ b/legateboost/legateboost.py
@@ -113,8 +113,12 @@ class LBBase(BaseEstimator, PickleCunumericMixin):
             name: str,
         ) -> None:
             eval_result[name][metric.name()].append(
-                metric.metric(
-                    y, self._objective_instance.transform(metric_pred), sample_weight
+                float(
+                    metric.metric(
+                        y,
+                        self._objective_instance.transform(metric_pred),
+                        sample_weight,
+                    )
                 )
             )
 

--- a/legateboost/legateboost.py
+++ b/legateboost/legateboost.py
@@ -28,6 +28,7 @@ EvalResult: TypeAlias = dict[str, dict[str, list[float]]]
 class LBBase(BaseEstimator, PickleCunumericMixin):
     def __init__(
         self,
+        *,
         n_estimators: int = 100,
         objective: Union[str, BaseObjective] = "squared_error",
         metric: Union[str, BaseMetric, list[Union[str, BaseMetric]]] = "default",
@@ -206,6 +207,7 @@ class LBBase(BaseEstimator, PickleCunumericMixin):
         self,
         X: cn.ndarray,
         y: cn.ndarray,
+        *,
         sample_weight: Optional[cn.ndarray] = None,
         eval_set: List[Tuple[cn.ndarray, ...]] = [],
         eval_result: EvalResult = {},
@@ -289,6 +291,7 @@ class LBBase(BaseEstimator, PickleCunumericMixin):
         self,
         X: cn.ndarray,
         y: cn.ndarray,
+        *,
         sample_weight: Optional[cn.ndarray] = None,
         eval_set: List[Tuple[cn.ndarray, ...]] = [],
         eval_result: EvalResult = {},
@@ -376,6 +379,7 @@ class LBBase(BaseEstimator, PickleCunumericMixin):
         self,
         X: cn.ndarray,
         y: cn.ndarray,
+        *,
         sample_weight: cn.ndarray,
         eval_set: List[Tuple[cn.ndarray, ...]] = [],
         eval_result: EvalResult = {},
@@ -423,7 +427,13 @@ class LBBase(BaseEstimator, PickleCunumericMixin):
         )
         self.is_fitted_ = True
 
-        return self._partial_fit(X, y, sample_weight, eval_set, eval_result)
+        return self._partial_fit(
+            X,
+            y,
+            sample_weight=sample_weight,
+            eval_set=eval_set,
+            eval_result=eval_result,
+        )
 
     def _predict(self, X: cn.ndarray) -> cn.ndarray:
         check_is_fitted(self, "is_fitted_")
@@ -450,6 +460,7 @@ class LBBase(BaseEstimator, PickleCunumericMixin):
         self,
         X: cn.array,
         y: cn.array,
+        *,
         metric: Optional[BaseMetric] = None,
         random_state: Optional[np.random.RandomState] = None,
         n_samples: int = 5,
@@ -512,6 +523,7 @@ class LBBase(BaseEstimator, PickleCunumericMixin):
         self,
         X: cn.array,
         X_background: cn.array,
+        *,
         random_state: Optional[np.random.RandomState] = None,
         n_samples: int = 5,
         check_efficiency: bool = False,
@@ -616,6 +628,7 @@ class LBRegressor(LBBase, RegressorMixin):
 
     def __init__(
         self,
+        *,
         n_estimators: int = 100,
         objective: Union[str, BaseObjective] = "squared_error",
         metric: Union[str, BaseMetric, list[Union[str, BaseMetric]]] = "default",
@@ -649,6 +662,7 @@ class LBRegressor(LBBase, RegressorMixin):
         self,
         X: cn.ndarray,
         y: cn.ndarray,
+        *,
         sample_weight: cn.ndarray = None,
         eval_set: List[Tuple[cn.ndarray, ...]] = [],
         eval_result: EvalResult = {},
@@ -695,6 +709,7 @@ class LBRegressor(LBBase, RegressorMixin):
         self,
         X: cn.ndarray,
         y: cn.ndarray,
+        *,
         sample_weight: cn.ndarray = None,
         eval_set: List[Tuple[cn.ndarray, ...]] = [],
         eval_result: EvalResult = {},
@@ -791,6 +806,7 @@ class LBClassifier(LBBase, ClassifierMixin):
 
     def __init__(
         self,
+        *,
         n_estimators: int = 100,
         objective: Union[str, BaseObjective] = "log_loss",
         metric: Union[str, BaseMetric, list[Union[str, BaseMetric]]] = "default",
@@ -819,6 +835,7 @@ class LBClassifier(LBBase, ClassifierMixin):
         self,
         X: cn.ndarray,
         y: cn.ndarray,
+        *,
         classes: Optional[cn.ndarray] = None,
         sample_weight: cn.ndarray = None,
         eval_set: List[Tuple[cn.ndarray, ...]] = [],
@@ -893,6 +910,7 @@ class LBClassifier(LBBase, ClassifierMixin):
         self,
         X: cn.ndarray,
         y: cn.ndarray,
+        *,
         sample_weight: cn.ndarray = None,
         eval_set: List[Tuple[cn.ndarray, ...]] = [],
         eval_result: EvalResult = {},

--- a/legateboost/library.py
+++ b/legateboost/library.py
@@ -66,7 +66,7 @@ class UserLibrary:
     def get_c_header(self) -> str:
         from .install_info import header
 
-        return header
+        return str(header)
 
     def get_registration_callback(self) -> str:
         return "legateboost_perform_registration"

--- a/legateboost/metrics.py
+++ b/legateboost/metrics.py
@@ -8,6 +8,18 @@ import cunumeric as cn
 from .special import erf, loggamma
 from .utils import pick_col_by_idx, sample_average, set_col_by_idx
 
+__all__ = [
+    "BaseMetric",
+    "MSEMetric",
+    "NormalLLMetric",
+    "GammaLLMetric",
+    "NormalCRPSMetric",
+    "GammaDevianceMetric",
+    "QuantileMetric",
+    "LogLossMetric",
+    "ExponentialMetric",
+]
+
 
 class BaseMetric(ABC):
     """The base class for metrics.
@@ -19,7 +31,7 @@ class BaseMetric(ABC):
     one = cn.ones(1, dtype=cn.float64)
 
     @abstractmethod
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         """Computes the metric between the true labels `y` and predicted labels
         `pred`, weighted by `w`.
 
@@ -67,7 +79,7 @@ class MSEMetric(BaseMetric):
         :class:`legateboost.objectives.SquaredErrorObjective`
     """
 
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         assert w.ndim == 1
         y = y.reshape(pred.shape)
         w_sum = w.sum()
@@ -109,7 +121,7 @@ class NormalLLMetric(BaseMetric):
         :class:`legateboost.objectives.NormalObjective`
     """  # noqa: E501
 
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         y, pred = check_dist_param(y, pred)
         w_sum = w.sum()
         if w_sum == 0:
@@ -136,7 +148,7 @@ class GammaLLMetric(BaseMetric):
     predicted by the model."""
 
     @override
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         y, pred = check_dist_param(y, pred)
 
         w_sum = w.sum()
@@ -174,7 +186,7 @@ class NormalCRPSMetric(BaseMetric):
         `Strictly Proper Scoring Rules, Prediction, and Estimation`
     """
 
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         y, pred = check_dist_param(y, pred)
         loc = pred[:, :, 0]
         # `NormalObjective` outputs variance instead of scale.
@@ -182,7 +194,7 @@ class NormalCRPSMetric(BaseMetric):
         z = (y - loc) / scale
         # This is negating the definition in [1] to make it a loss.
         v = scale * (z * (2 * norm_cdf(z) - 1) + 2 * norm_pdf(z) - 1 / cn.sqrt(cn.pi))
-        return sample_average(v, w)
+        return float(sample_average(v, w))
 
     def name(self) -> str:
         return "normal_crps"
@@ -194,7 +206,7 @@ class GammaDevianceMetric(BaseMetric):
     :math:`E = 2[(\\ln{\\frac{p_i}{y_i}} + \\frac{y_i}{p_i} - 1)w_i]`
     """
 
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         eps = 1e-6
         y = y + eps
         pred = pred + eps
@@ -226,14 +238,14 @@ class QuantileMetric(BaseMetric):
         assert cn.all(0.0 <= quantiles) and cn.all(quantiles <= self.one)
         self.quantiles = quantiles
 
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         assert w.ndim == 1
         assert y.shape[1] == 1
         assert pred.shape[1] == self.quantiles.size
         diff = y - pred
         indicator = diff <= 0
         loss = (self.quantiles[cn.newaxis, :] - indicator) * diff
-        return ((loss * w[:, cn.newaxis]).sum() / self.quantiles.size) / w.sum()
+        return float(((loss * w[:, cn.newaxis]).sum() / self.quantiles.size) / w.sum())
 
     def name(self) -> str:
         return "quantile"
@@ -258,7 +270,7 @@ class LogLossMetric(BaseMetric):
         :class:`legateboost.objectives.LogLossObjective`
     """  # noqa: E501
 
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         y = y.squeeze()
         eps = cn.finfo(pred.dtype).eps
         cn.clip(pred, eps, 1 - eps, out=pred)
@@ -296,13 +308,13 @@ class ExponentialMetric(BaseMetric):
         :class:`legateboost.objectives.ExponentialObjective`
     """  # noqa: E501
 
-    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> float:
+    def metric(self, y: cn.ndarray, pred: cn.ndarray, w: cn.ndarray) -> cn.ndarray:
         y = y.squeeze()
         # binary case
         if pred.ndim == 1 or pred.shape[1] == 1:
             pred = pred.squeeze()
             exp = cn.power(pred / (self.one - pred), 0.5 - y)
-            return float((exp * w).sum() / w.sum())
+            return (exp * w).sum() / w.sum()
 
         # multi-class case
         # note that exp loss is invariant to adding a constant to prediction
@@ -314,7 +326,7 @@ class ExponentialMetric(BaseMetric):
         # y_k[cn.arange(y.size), y.astype(cn.int32)] = 1.0
 
         exp = cn.exp(-1 / K * cn.sum(y_k * f, axis=1))
-        return float((exp * w).sum() / w.sum())
+        return (exp * w).sum() / w.sum()
 
     def name(self) -> str:
         return "exp"

--- a/legateboost/metrics.py
+++ b/legateboost/metrics.py
@@ -93,7 +93,7 @@ class MSEMetric(BaseMetric):
         # per output
         mse = numerator / w_sum
         # average over outputs
-        return float(mse.mean())
+        return mse.mean()
 
     def name(self) -> str:
         return "mse"
@@ -137,7 +137,7 @@ class NormalLLMetric(BaseMetric):
         # ll = -0.5 * cn.log(2 * cn.pi) + 2 * log_sigma - 0.5 * (diff * diff) / var
         neg_ll = (neg_ll * w).sum(axis=0) / w_sum
         # average over output
-        return float(neg_ll.mean())
+        return neg_ll.mean()
 
     def name(self) -> str:
         return "normal_neg_ll"
@@ -159,7 +159,7 @@ class GammaLLMetric(BaseMetric):
         b = pred[:, :, 1]
         error = -(k - 1) * cn.log(y) + y / (b + 1e-6) + k * cn.log(b) + loggamma(k)
 
-        return float(sample_average(error, w))
+        return sample_average(error, w)
 
     @override
     def name(self) -> str:
@@ -194,7 +194,7 @@ class NormalCRPSMetric(BaseMetric):
         z = (y - loc) / scale
         # This is negating the definition in [1] to make it a loss.
         v = scale * (z * (2 * norm_cdf(z) - 1) + 2 * norm_pdf(z) - 1 / cn.sqrt(cn.pi))
-        return float(sample_average(v, w))
+        return sample_average(v, w)
 
     def name(self) -> str:
         return "normal_crps"
@@ -214,7 +214,7 @@ class GammaDevianceMetric(BaseMetric):
         result = sample_average(d, w)
         if result.size > 1:
             result = cn.average(result)
-        return float(result)
+        return result
 
     def name(self) -> str:
         return "deviance_gamma"
@@ -245,7 +245,7 @@ class QuantileMetric(BaseMetric):
         diff = y - pred
         indicator = diff <= 0
         loss = (self.quantiles[cn.newaxis, :] - indicator) * diff
-        return float(((loss * w[:, cn.newaxis]).sum() / self.quantiles.size) / w.sum())
+        return ((loss * w[:, cn.newaxis]).sum() / self.quantiles.size) / w.sum()
 
     def name(self) -> str:
         return "quantile"

--- a/legateboost/models/__init__.py
+++ b/legateboost/models/__init__.py
@@ -3,3 +3,6 @@ from .linear import Linear
 from .krr import KRR
 from .nn import NN
 from .base_model import BaseModel
+from typing import List
+
+__all__: List[str] = ["Tree", "Linear", "KRR", "NN", "BaseModel"]

--- a/legateboost/models/krr.py
+++ b/legateboost/models/krr.py
@@ -219,6 +219,7 @@ class KRR(BaseModel):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, KRR):
             raise NotImplementedError()
-        return (other.betas_ == self.betas_).all() and (
-            other.X_train == self.X_train
-        ).all()
+        return bool(
+            (other.betas_ == self.betas_).all()
+            and (other.X_train == self.X_train).all()
+        )

--- a/legateboost/models/linear.py
+++ b/legateboost/models/linear.py
@@ -121,4 +121,4 @@ class Linear(BaseModel):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Linear):
             raise NotImplementedError()
-        return (other.betas_ == self.betas_).all()
+        return bool((other.betas_ == self.betas_).all())

--- a/legateboost/objectives.py
+++ b/legateboost/objectives.py
@@ -21,6 +21,17 @@ from .utils import mod_col_by_idx, sample_average, set_col_by_idx
 
 GradPair: TypeAlias = Tuple[cn.ndarray, cn.ndarray]
 
+__all__ = [
+    "BaseObjective",
+    "SquaredErrorObjective",
+    "NormalObjective",
+    "LogLossObjective",
+    "ExponentialObjective",
+    "QuantileObjective",
+    "GammaDevianceObjective",
+    "GammaObjective",
+]
+
 
 class BaseObjective(ABC):
     """The base class for objective functions.

--- a/legateboost/shapley.py
+++ b/legateboost/shapley.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 from sklearn.base import is_regressor
@@ -11,6 +11,8 @@ from .metrics import BaseMetric
 # provide definitions for mypy without circular import at runtime
 if TYPE_CHECKING:
     from .legateboost import LBBase
+
+__all__: List[str] = []
 
 
 def global_shapley_attributions(

--- a/legateboost/special.py
+++ b/legateboost/special.py
@@ -15,12 +15,15 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import List
 
 import cunumeric as cn
 from legate.core import get_legate_runtime, types as ty
 
 from .library import user_context, user_lib
 from .utils import get_store
+
+__all__: List[str] = []
 
 
 class _SpecialOpCode(IntEnum):

--- a/legateboost/test/models/test_linear.py
+++ b/legateboost/test/models/test_linear.py
@@ -30,7 +30,7 @@ class TestLinear:
             base_models=(lb.models.Linear(),),
             init=None,
             learning_rate=1.0,
-        ).fit(X, y, w)
+        ).fit(X, y, sample_weight=w)
         assert cn.allclose(
             model.models_[0].betas_[0], np.average(y, axis=0, weights=w), atol=1e-5
         )

--- a/legateboost/test/test_shapley.py
+++ b/legateboost/test/test_shapley.py
@@ -14,7 +14,7 @@ def test_regressor_global_shapley_attributions(random_state, metric, num_outputs
     shapley, se = model.global_attributions(
         X,
         y,
-        metric,
+        metric=metric,
         n_samples=20,
         random_state=random_state,
         check_efficiency=True,
@@ -34,7 +34,7 @@ def test_classifier_global_shapley_attributions(metric, num_classes):
     shapley, se = model.global_attributions(
         X,
         y,
-        metric,
+        metric=metric,
         random_state=9,
         check_efficiency=True,
     )

--- a/legateboost/utils.py
+++ b/legateboost/utils.py
@@ -14,6 +14,8 @@ from legate.core import (
 
 from .library import user_context, user_lib
 
+__all__: List[str] = []
+
 
 class PickleCunumericMixin:
     """When reading back from pickle, convert numpy arrays to cunumeric

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,10 @@ verbose = true
 version = {file = "legateboost/VERSION"}
 
 [tool.mypy]
-
-disallow_untyped_defs = true
+strict = true
 follow_imports = "skip"
 ignore_missing_imports = true
+disallow_subclassing_any = false # mypy has no type info for sklearn base classes
 
 [tool.isort]
 


### PR DESCRIPTION
An attempt at addressing #143 

Enforces the use of keyword arguments for most arguments except X, y. 

Implements `__all__` for modules. I am not sure if there needs to be an `__all__` at the `__init__` level. I have left it out for now.

Mypy has been set to 'strict' which seems to enforce some classes being included in `__all__`.

I've looked for linting tools to help me more strictly enforce the above, but mypy strict seems to be about the best I could find.