### PR TITLE
BLD: Use the newest legate-nightlies

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -41,4 +41,6 @@ rapids-mamba-retry install \
 
 rapids-print-env
 
+# Force minimal resource use as auto-configure may fail with few cores.
+LEGATE_CONFIG="--cpus=1 --gpus=0 --omps=0 --utility=1" \
 make -C docs html

--- a/conda/environments/all_cuda-122.yaml
+++ b/conda/environments/all_cuda-122.yaml
@@ -10,9 +10,9 @@ dependencies:
 - cuda-cudart-dev
 - cuda-nvcc
 - cuda-version>=12.2
-- cunumeric==24.09.*,>=0.0.0.dev0
+- cunumeric==25.01.*,>=0.0.0.dev0
 - hypothesis>=6
-- legate==24.09.*,>=0.0.0.dev0
+- legate==25.01.*,>=0.0.0.dev0
 - libcublas-dev
 - make
 - matplotlib>=3.9

--- a/conda/recipes/legate-boost/conda_build_config.yaml
+++ b/conda/recipes/legate-boost/conda_build_config.yaml
@@ -26,10 +26,7 @@ gpu_enabled:
   - false
 
 cunumeric_version:
-  # .dev116: https://github.com/nv-legate/legate.core.internal/issues/1409
-  - "=24.09.*,>=0.0.0.dev0,!=24.09.00.dev116"
+  - "=25.01.*,>=0.0.0.dev0"
 
 legate_version:
-  # .dev319: https://github.com/nv-legate/legate.core.internal/pull/1401
-  # .dev329: https://github.com/nv-legate/legate.core.internal/issues/1409
-  - "=24.09.*,>=0.0.0.dev0,!=24.09.00.dev319,!=24.09.00.dev329"
+  - "=25.01.*,>=0.0.0.dev0"

--- a/conda/recipes/legate-boost/meta.yaml
+++ b/conda/recipes/legate-boost/meta.yaml
@@ -118,14 +118,16 @@ requirements:
 test:
   # import tests at build time do not work for the CUDA packages,
   # because builds happen on machines without a GPU
-  {% if not gpu_enabled_bool %}
-  imports:
-    - legateboost
-    - legateboost.metrics
-    - legateboost.models
-    - legateboost.objectives
-  {% endif %}
   commands:
+  {% if not gpu_enabled_bool %}
+    # Force minimal resource use as auto-configure may fail with few cores
+    # otherwise, should use `imports:` section.
+    - LEGATE_CONFIG="--cpus=1 --gpus=0 --omps=0 --utility=1"
+      python -c "import legateboost;
+                 import legateboost.metrics;
+                 import legateboost.models;
+                 import legateboost.objectives"
+  {% endif %}
     - pip show legate-boost
 
 about:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -61,7 +61,7 @@ dependencies:
       - output_types: [conda, pyproject, requirements]
         packages:
           - cmake>=3.24.0,!=3.30.0
-          - &legate legate==24.09.*,>=0.0.0.dev0
+          - &legate legate==25.01.*,>=0.0.0.dev0
           - ninja>=1.11.1.1
           - scikit-build>=0.18.0
           - setuptools>=70.0
@@ -123,7 +123,7 @@ dependencies:
           - typing-extensions>=4.0
       - output_types: [conda, pyproject, requirements]
         packages:
-          - cunumeric==24.09.*,>=0.0.0.dev0
+          - cunumeric==25.01.*,>=0.0.0.dev0
           - *legate
   test:
     common:

--- a/legateboost/test/test_examples.py
+++ b/legateboost/test/test_examples.py
@@ -65,7 +65,8 @@ def test_benchmark(benchmark_dir):
     del env["LEGATE_CONFIG"]
 
     subprocess.run(
-        "legate --cpus 2 legateboost_scaling.py --nrows 100 --ncols 5 --niter 2"
+        "legate --cpus=2 --gpus=0"
+        + " legateboost_scaling.py --nrows 100 --ncols 5 --niter 2"
         + " --model_types tree,linear,krr,nn",
         shell=True,
         check=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cmake>=3.24.0,!=3.30.0",
-    "legate==24.09.*,>=0.0.0.dev0",
+    "legate==25.01.*,>=0.0.0.dev0",
     "ninja>=1.11.1.1",
     "scikit-build>=0.18.0",
     "setuptools>=70.0",
@@ -24,8 +24,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "cunumeric==24.09.*,>=0.0.0.dev0",
-    "legate==24.09.*,>=0.0.0.dev0",
+    "cunumeric==25.01.*,>=0.0.0.dev0",
+    "legate==25.01.*,>=0.0.0.dev0",
     "numpy",
     "scikit-learn",
     "typing-extensions>=4.0",


### PR DESCRIPTION
Since we want to do a release, this is not quite ideal as it is the state after the release really.  But for testing purposes the 25.01 nightlies are more useful (because recent other nightlies all had one issue or another).

---

I think it may be nice to try all packages together once.  But I can't build the others with any 24.09.dev version.  So maybe build legate-boost with the latest nightlies as well?