### PR TITLE
BLD: Relax version pin on cuda libraries

### DIFF
--- a/conda/recipes/legate-boost/meta.yaml
+++ b/conda/recipes/legate-boost/meta.yaml
@@ -58,6 +58,8 @@ build:
   ignore_run_exports_from:
     {% if gpu_enabled_bool %}
     - {{ compiler('cuda') }}
+    - cuda-cudart-dev
+    - libcublas-dev
     {% endif %}
   {% if not gpu_enabled_bool %}
   # The CPU-only packages having more track_features than the GPU builds helps
@@ -98,6 +100,8 @@ requirements:
     {% if gpu_enabled_bool %}
     # cuda-version is used to constrain __cuda
     - {{ pin_compatible('cuda-version', max_pin='x', min_pin='x') }}
+    - cuda-cudart
+    - libcublas
     - __cuda
     - cunumeric {{ cunumeric_version }} =*_gpu*
     {% else %}


### PR DESCRIPTION
cuda-cudart-dev and libcublas-dev have exact version requirement exports by default.
This is almost always overly strict, by ignoring thei run-exports and then adding them as simple dependencies we relax those version pins.