### PR TITLE
MAINT: Enable support/allow compiling for one-pool

### DIFF
--- a/conda/environments/all_cuda-122.yaml
+++ b/conda/environments/all_cuda-122.yaml
@@ -31,6 +31,7 @@ dependencies:
 - python-build>=1.2.0
 - python=3.12
 - rapids-build-backend>=0.3.2,<0.4.0.dev0
+- rich
 - scikit-build-core>=0.10.0
 - scikit-learn>=1.6
 - seaborn>=0.13

--- a/conda/environments/all_cuda-122.yaml
+++ b/conda/environments/all_cuda-122.yaml
@@ -17,6 +17,7 @@ dependencies:
 - hypothesis>=6
 - legate==25.01.*,>=0.0.0.dev0
 - libcublas-dev
+- llvm-openmp
 - make
 - matplotlib>=3.9
 - mypy>=1.13

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -88,6 +88,7 @@ dependencies:
           - cuda-toolkit
           - clang-tools>=19.0
           - clangxx>=19.0
+          - rich
   build_tools:
     common:
       - output_types: [conda]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -88,6 +88,7 @@ dependencies:
           - cuda-toolkit
           - clang-tools>=19.0
           - clangxx>=19.0
+          - llvm-openmp
           - rich
   build_tools:
     common:

--- a/src/mapper.cc
+++ b/src/mapper.cc
@@ -24,8 +24,9 @@ namespace legateboost {
 
 LegateboostMapper::LegateboostMapper() = default;
 
-std::optional<std::size_t> LegateboostMapper::allocation_pool_size(
-  const legate::mapping::Task& task, legate::mapping::StoreTarget memory_kind)
+auto LegateboostMapper::allocation_pool_size(const legate::mapping::Task& /* task */,
+                                             legate::mapping::StoreTarget memory_kind)
+  -> std::optional<std::size_t>
 {
   if (memory_kind == legate::mapping::StoreTarget::ZCMEM) { return 0; }
   // TODO(seberg): nullopt means we give no upper bound.  For tasks that use

--- a/src/mapper.cc
+++ b/src/mapper.cc
@@ -24,6 +24,16 @@ namespace legateboost {
 
 LegateboostMapper::LegateboostMapper() = default;
 
+std::optional<std::size_t> LegateboostMapper::allocation_pool_size(
+  const legate::mapping::Task& task, legate::mapping::StoreTarget memory_kind)
+{
+  if (memory_kind == legate::mapping::StoreTarget::ZCMEM) { return 0; }
+  // TODO(seberg): nullopt means we give no upper bound.  For tasks that use
+  // `legate::VariantOptions{}.with_has_allocations(true);` giving a bound
+  // may improve parallelism.
+  return std::nullopt;
+}
+
 auto LegateboostMapper::tunable_value(legate::TunableID /*tunable_id*/) -> legate::Scalar
 {
   return legate::Scalar{};

--- a/src/mapper.h
+++ b/src/mapper.h
@@ -31,6 +31,8 @@ class LegateboostMapper : public legate::mapping::Mapper {
 
   // Legate mapping functions
 
+  std::optional<std::size_t> allocation_pool_size(
+    const legate::mapping::Task& task, legate::mapping::StoreTarget memory_kind) override;
   auto store_mappings(const legate::mapping::Task& task,
                       const std::vector<legate::mapping::StoreTarget>& options)
     -> std::vector<legate::mapping::StoreMapping> override;

--- a/src/mapper.h
+++ b/src/mapper.h
@@ -31,8 +31,9 @@ class LegateboostMapper : public legate::mapping::Mapper {
 
   // Legate mapping functions
 
-  std::optional<std::size_t> allocation_pool_size(
-    const legate::mapping::Task& task, legate::mapping::StoreTarget memory_kind) override;
+  auto allocation_pool_size(const legate::mapping::Task& task,
+                            legate::mapping::StoreTarget memory_kind)
+    -> std::optional<std::size_t> override;
   auto store_mappings(const legate::mapping::Task& task,
                       const std::vector<legate::mapping::StoreTarget>& options)
     -> std::vector<legate::mapping::StoreMapping> override;

--- a/src/models/nn/build_nn.h
+++ b/src/models/nn/build_nn.h
@@ -165,6 +165,9 @@ class LearningMonitor {
 
 class BuildNNTask : public Task<BuildNNTask, BUILD_NN> {
  public:
+  static constexpr auto CPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
+
   static void cpu_variant(legate::TaskContext context);
 #ifdef LEGATEBOOST_USE_CUDA
   static void gpu_variant(legate::TaskContext context);

--- a/src/models/tree/build_tree.h
+++ b/src/models/tree/build_tree.h
@@ -246,10 +246,10 @@ class Histogram {
 };
 
 class BuildTreeTask : public Task<BuildTreeTask, BUILD_TREE> {
+ public:
   static constexpr auto CPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
   static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
 
- public:
   static void cpu_variant(legate::TaskContext context);
 #ifdef LEGATEBOOST_USE_CUDA
   static void gpu_variant(legate::TaskContext context);

--- a/src/models/tree/build_tree.h
+++ b/src/models/tree/build_tree.h
@@ -246,6 +246,9 @@ class Histogram {
 };
 
 class BuildTreeTask : public Task<BuildTreeTask, BUILD_TREE> {
+  static constexpr auto CPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
+
  public:
   static void cpu_variant(legate::TaskContext context);
 #ifdef LEGATEBOOST_USE_CUDA

--- a/src/models/tree/update_tree.cc
+++ b/src/models/tree/update_tree.cc
@@ -118,6 +118,8 @@ struct update_tree_fn {
 };
 
 class UpdateTreeTask : public Task<UpdateTreeTask, UPDATE_TREE> {
+  static constexpr auto CPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
+
  public:
   static void cpu_variant(legate::TaskContext context)
   {

--- a/src/models/tree/update_tree.cc
+++ b/src/models/tree/update_tree.cc
@@ -118,9 +118,9 @@ struct update_tree_fn {
 };
 
 class UpdateTreeTask : public Task<UpdateTreeTask, UPDATE_TREE> {
+ public:
   static constexpr auto CPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
 
- public:
   static void cpu_variant(legate::TaskContext context)
   {
     const auto& X = context.input(0).data();

--- a/src/utils/gather.h
+++ b/src/utils/gather.h
@@ -21,6 +21,9 @@ namespace legateboost {
 
 class GatherTask : public Task<GatherTask, GATHER> {
  public:
+  // GPU variant may create buffer to copy from host
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
+
   static void cpu_variant(legate::TaskContext context);
 #ifdef LEGATEBOOST_USE_CUDA
   static void gpu_variant(legate::TaskContext context);


### PR DESCRIPTION
The simple unary tasks do not require any allocations, so do not set them. For the other tasks, we indicate that allocations are required, but for now do not attempt to give a meaningful upper bound.
(Except for ZCOPY memory, as it is not used right now.)

---

~Marking as draft, didn't do proper local testing (yet).~ I think it should be working now, clang-tidy also seems to have it's dependencies (I hope).