### PR TITLE
BLD: Temporarily add the branch-25.01 label for the release [skip ci]

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -35,6 +35,7 @@ rapids-mamba-retry install \
   --override-channels \
   --channel "${RAPIDS_LOCAL_CONDA_CHANNEL}" \
   --channel legate \
+  --channel legate/label/branch-25.01 \
   --channel legate/label/experimental \
   --channel conda-forge \
   "legate-boost=${LEGATEBOOST_VERSION}"

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -11,6 +11,7 @@ CONDA_OVERRIDE_CUDA="${RAPIDS_CUDA_VERSION}" \
 LEGATEBOOST_PACKAGE_VERSION=$(head -1 ./VERSION) \
 rapids-conda-retry mambabuild \
     --channel legate \
+    --channel legate/label/branch-25.01 \
     --channel legate/label/experimental \
     --channel conda-forge \
     --channel nvidia \

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -41,6 +41,7 @@ rapids-mamba-retry install \
   --name test-env \
   --channel "${RAPIDS_LOCAL_CONDA_CHANNEL}" \
   --channel legate \
+  --channel legate/label/branch-25.01 \
   --channel legate/label/experimental \
   --channel conda-forge \
     "legate-boost=${LEGATEBOOST_VERSION}"

--- a/conda/environments/all_cuda-122.yaml
+++ b/conda/environments/all_cuda-122.yaml
@@ -3,6 +3,7 @@
 channels:
 - rapidsai
 - legate
+- legate/label/branch-25.01
 - legate/label/experimental
 - conda-forge
 - nvidia

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,6 +66,7 @@ files:
 channels:
   - rapidsai
   - legate
+  - legate/label/branch-25.01
   - legate/label/experimental
   - conda-forge
   - nvidia


### PR DESCRIPTION
This adds the branch-25.01 label to pick up the legate "release candidate" for our 25.01 release.

NOTE: I think we can merge this as is, however, unless we remove the `v25.01.00` label, we should abort the after-merge CI action (to avoid uploading a "nightly" with a funny version).