### PR TITLE
enable sccache in builds, update some pre-commit hooks

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -13,6 +13,11 @@ on:
         type: string
         description: "relative path to a script that builds conda packages"
 
+# override default permissions
+permissions:
+  # needed to auth with AWS for sccache
+  id-token: write
+
 env:
   # CUDA architectures to build for
   CUDAARCHS: "all-major"
@@ -47,6 +52,11 @@ jobs:
     container:
       image: "rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-ubuntu22.04-py${{ matrix.PY_VER }}"
     steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          role-duration-seconds: 14400 # 4h
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
           files: \.(cu|cuh|h|cc|inl)$
           types_or: []
     - repo: https://github.com/rapidsai/dependency-file-generator
-      rev: v1.16.0
+      rev: v1.17.1
       hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -2,9 +2,14 @@
 
 set -e -E -u -o pipefail
 
+# shellcheck disable=SC1091
+source rapids-configure-sccache
+
 rapids-print-env
 
 rapids-generate-version > ./VERSION
+
+sccache --zero-stats
 
 CMAKE_GENERATOR=Ninja \
 CONDA_OVERRIDE_CUDA="${RAPIDS_CUDA_VERSION}" \
@@ -17,6 +22,8 @@ rapids-conda-retry mambabuild \
     --channel nvidia \
     --no-force-upload \
     conda/recipes/legate-boost
+
+sccache --show-adv-stats
 
 # echo package details to logs, to help with debugging
 conda search \


### PR DESCRIPTION
## Description

Similar to https://github.com/rapidsai/legate-raft/pull/15

Enables `sccache` in builds, to hopefully save some CI time, memory, and compute.

Since I'm touching the repo anyway, also updates the RAPIDS-specific `pre-commit` hooks to their latest versions.