### PR TITLE
Replace `conda-mambabuild`with `conda-build`

### DIFF
--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -14,7 +14,7 @@ sccache --zero-stats
 CMAKE_GENERATOR=Ninja \
 CONDA_OVERRIDE_CUDA="${RAPIDS_CUDA_VERSION}" \
 LEGATEBOOST_PACKAGE_VERSION=$(head -1 ./VERSION) \
-rapids-conda-retry mambabuild \
+rapids-conda-retry build \
     --channel legate \
     --channel legate/label/branch-25.01 \
     --channel legate/label/experimental \

--- a/contributing.md
+++ b/contributing.md
@@ -108,7 +108,7 @@ Build the packages.
 CMAKE_GENERATOR=Ninja \
 CONDA_OVERRIDE_CUDA="${RAPIDS_CUDA_VERSION}" \
 LEGATEBOOST_PACKAGE_VERSION=$(head -1 ./VERSION) \
-rapids-conda-retry mambabuild \
+rapids-conda-retry build \
     --channel legate \
     --channel conda-forge \
     --channel nvidia \


### PR DESCRIPTION
These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149