### PR TITLE
Fix for GPU workers going out of sync

### DIFF
--- a/src/models/tree/build_tree.cu
+++ b/src/models/tree/build_tree.cu
@@ -551,6 +551,8 @@ struct HistogramKernel {
                       int64_t seed,
                       cudaStream_t stream)
   {
+    if (batch.InstancesInBatch() == 0) return;
+
     int const average_features_per_group = split_proposals.num_features / num_groups;
     std::size_t const average_elements_per_group =
       batch.InstancesInBatch() * average_features_per_group;

--- a/src/models/tree/build_tree.h
+++ b/src/models/tree/build_tree.h
@@ -158,12 +158,12 @@ class SparseSplitProposals {
   legate::Buffer<T, 1> split_proposals;
   legate::Buffer<int32_t, 1> row_pointers;
   int32_t num_features;
-  int32_t histogram_size;
+  std::size_t histogram_size;
   // The rightmost split proposal for each feature must be +inf
   SparseSplitProposals(const legate::Buffer<T, 1>& split_proposals,
                        const legate::Buffer<int32_t, 1>& row_pointers,
                        int32_t num_features,
-                       int32_t histogram_size)
+                       std::size_t histogram_size)
     : split_proposals(split_proposals),
       row_pointers(row_pointers),
       num_features(num_features),
@@ -234,7 +234,7 @@ class Histogram {
     : buffer_(legate::create_buffer<GPairT, 3>({node_end - node_begin, num_outputs, num_bins})),
       node_begin_(node_begin),
       node_end_(node_end),
-      size_(static_cast<std::size_t>((node_end - node_begin) * num_outputs * num_bins))
+      size_(static_cast<std::size_t>(node_end - node_begin) * num_outputs * num_bins)
   {
     static_assert(sizeof(GPairT) == 2 * sizeof(typename GPairT::value_type),
                   "Unexpected size of GPairT");
@@ -249,7 +249,7 @@ class Histogram {
     : buffer_(legate::create_buffer<GPairT, 3>({node_end - node_begin, num_outputs, num_bins})),
       node_begin_(node_begin),
       node_end_(node_end),
-      size_(static_cast<std::size_t>((node_end - node_begin) * num_outputs * num_bins))
+      size_(static_cast<std::size_t>(node_end - node_begin) * num_outputs * num_bins)
   {
     static_assert(sizeof(GPairT) == 2 * sizeof(typename GPairT::value_type),
                   "Unexpected size of GPairT");


### PR DESCRIPTION
This fixes #217.

The issue occurs because when a local worker prepares a batch of data and sees that it is empty, it discards this batch. The problem is that the other worker may still have data for this batch. This results in the two workers queing different work where they should be in sync.