### PR TITLE
MAINT: Prepare for building a 25.03 release

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -35,6 +35,7 @@ rapids-mamba-retry install \
   --override-channels \
   --channel "${RAPIDS_LOCAL_CONDA_CHANNEL}" \
   --channel legate \
+  --channel legate/label/rc \
   --channel legate/label/experimental \
   --channel conda-forge \
   "legate-boost=${LEGATEBOOST_VERSION}"

--- a/ci/build_python.sh
+++ b/ci/build_python.sh
@@ -16,6 +16,7 @@ CONDA_OVERRIDE_CUDA="${RAPIDS_CUDA_VERSION}" \
 LEGATEBOOST_PACKAGE_VERSION=$(head -1 ./VERSION) \
 rapids-conda-retry build \
     --channel legate \
+    --channel legate/label/rc \
     --channel legate/label/experimental \
     --channel conda-forge \
     --channel nvidia \

--- a/ci/test_python_common.sh
+++ b/ci/test_python_common.sh
@@ -41,6 +41,7 @@ rapids-mamba-retry install \
   --name test-env \
   --channel "${RAPIDS_LOCAL_CONDA_CHANNEL}" \
   --channel legate \
+  --channel legate/label/rc \
   --channel legate/label/experimental \
   --channel conda-forge \
     "legate-boost=${LEGATEBOOST_VERSION}"

--- a/conda/environments/all_cuda-122.yaml
+++ b/conda/environments/all_cuda-122.yaml
@@ -3,6 +3,7 @@
 channels:
 - rapidsai
 - legate
+- legate/label/rc
 - legate/label/experimental
 - conda-forge
 - nvidia

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -66,6 +66,7 @@ files:
 channels:
   - rapidsai
   - legate
+  - legate/label/rc
   - legate/label/experimental
   - conda-forge
   - nvidia


### PR DESCRIPTION
Add the `rc` label again to prefer `rc` releases (we can really just keep it around indefinitely).

If this passes, we should be good for doing/tagging a 25.03 release at any point.
(All rc package dependencies look correct to me.)

*EDIT: No, the dependencies seems subtly wrong in some places, so we _can't_ just do a release once this is in as of early 03-14.*